### PR TITLE
Generator Method: Missing parameters

### DIFF
--- a/adalflow/adalflow/core/generator.py
+++ b/adalflow/adalflow/core/generator.py
@@ -813,7 +813,12 @@ class Generator(GradComponent, CachedEngine, CallbackManager):
                 output = GeneratorOutput(raw_response=str(completion), error=str(e))
 
         log.info(f"output: {output}")
-        self._run_callbacks(output, input=api_kwargs)
+        self._run_callbacks(
+            output,
+            input=api_kwargs,
+            prompt_kwargs=prompt_kwargs,
+            model_kwargs=model_kwargs,
+        )
         return output
 
     def __call__(self, *args, **kwargs) -> Union[GeneratorOutputType, Any]:


### PR DESCRIPTION
_run_callbacks class method, within the acall method, missing parameters.

Error message:
`TypeError: Generator._run_callbacks() missing 2 required positional arguments: 'prompt_kwargs' and 'model_kwargs'`

Added parameters to method.