### PR TITLE
299 ollama client does not work with stream

### DIFF
--- a/adalflow/adalflow/core/generator.py
+++ b/adalflow/adalflow/core/generator.py
@@ -7,7 +7,16 @@ import re
 import os
 from pathlib import Path
 
-from typing import Any, Dict, Optional, Union, Callable, Tuple, List
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Union,
+    Callable,
+    Tuple,
+    List,
+    Generator as GeneratorType,
+)
 import logging
 
 
@@ -304,24 +313,54 @@ class Generator(GradComponent, CachedEngine, CallbackManager):
         s = f"model_kwargs={self.model_kwargs}, model_type={self.model_type}"
         return s
 
+    def _process_chunk(self, chunk: Any) -> GeneratorOutput:
+        """Process a single chunk of data using the output processors.
+
+        Args:
+            chunk: Raw chunk data to process
+
+        Returns:
+            Any: Processed chunk
+            str: Error string in case of an exception
+        """
+        if not chunk or not self.output_processors:
+            return chunk, None
+
+        try:
+            processed_data = self.output_processors(chunk)
+            return processed_data, None
+        except Exception as e:
+            log.error(f"Error processing chunk using the output processors: {e}")
+            return None, str(e)
+
     def _post_call(self, completion: Any) -> GeneratorOutput:
-        r"""Get string completion and process it with the output_processors."""
-        # parse chat completion will only fill the raw_response
-        output: GeneratorOutput = self.model_client.parse_chat_completion(completion)
-        # Now adding the data filed to the output
-        data = output.raw_response
-        if self.output_processors:
-            if data:
+        """Process completion output, handling both streaming and non-streaming cases.
+
+        Args:
+            completion: Raw completion data from the llm provider
+
+        Returns:
+            GeneratorOutput containing processed data or generator type
+        """
+        # Parse chat completion will only fill the raw_response
+        output = self.model_client.parse_chat_completion(completion)
+        # Handle streaming case
+        if isinstance(output, GeneratorType):
+
+            def process_stream():
                 try:
-                    data = self.output_processors(data)
-                    output.data = data
+                    for out in output:
+                        log.debug(f"Processing raw chunk: {out.raw_response}")
+                        out.data, out.error = self._process_chunk(out.raw_response)
+                        yield out
                 except Exception as e:
-                    log.error(f"Error processing the output processors: {e}")
-                    output.error = str(e)
+                    log.error(f"Error in stream processing: {e}")
+                    yield GeneratorOutput(error=str(e))
 
+            return GeneratorOutput(data=process_stream(), raw_response=output)
         else:
-            output.data = data
-
+            # Handle non-streaming case
+            output.data, output.error = self._process_chunk(output.raw_response)
         return output
 
     def _pre_call(self, prompt_kwargs: Dict, model_kwargs: Dict) -> Dict[str, Any]:


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue where the application fails to work when the `stream` parameter is set to `True` in the `adalflow.components.model_client.ollama_client::OllamaClient` class. The issue is traced to the `adalflow.core.generator.py` `_post_call` method, which does not currently handle streaming correctly.

### Fixes #299
- Implements separate cases for handling streaming and non-streaming responses in the `_post_call` method.
  - For streaming responses: Processes the raw response from the completion generator as it is yielded and passes it to the `output_processors`.
  - For non-streaming responses: Retains the existing behavior.

### Usage Updates
The updated usage for the `stream` parameter is as follows:

```python
ollama_ai = {
    "model_client": OllamaClient(host=host),
    "model_kwargs": {
        "model": "phi3:latest",
        "stream": True,
    },
}

generator = Generator(**ollama_ai)
output = generator({"input_str": "What is the capital of France?"})
for chunk in output.data:
    print(chunk.data, end="", flush=True)

# For stream: False
# print(output.data)
```

### Tests Added
- A new test case, `TestGeneratorWithStream`, is added in `test_generator.py` to verify the streaming behavior.
  - The test mocks the `GeneratorType` response from the `parse_chat_completion` method and validates the output for streamed data.

### Tests output (local) after changes:

```bash
======================================================== test session starts =========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/AdalFlow
configfile: pyproject.toml
plugins: anyio-4.4.0, mock-3.14.0
collected 231 items / 1 skipped                                                                                                      

adalflow/tests/test_AzureClient.py ..                                                                                          [  0%]
adalflow/tests/test_base_data_class.py ..............                                                                          [  6%]
adalflow/tests/test_component.py ...                                                                                           [  8%]
adalflow/tests/test_componentlist.py .............                                                                             [ 13%]
adalflow/tests/test_data.py ...                                                                                                [ 15%]
adalflow/tests/test_data_class_parser.py ......                                                                                [ 17%]
adalflow/tests/test_data_classes.py ....                                                                                       [ 19%]
adalflow/tests/test_data_loader.py .......                                                                                     [ 22%]
adalflow/tests/test_dataclass_object_functions.py ................                                                             [ 29%]
adalflow/tests/test_evaluators.py ..s                                                                                          [ 30%]
adalflow/tests/test_faiss_retriever.py .........                                                                               [ 34%]
adalflow/tests/test_function_expression_parse.py ........................                                                      [ 45%]
adalflow/tests/test_generator.py ......                                                                                        [ 47%]
adalflow/tests/test_generator_call_logger.py ...                                                                               [ 48%]
adalflow/tests/test_grad_component.py ......                                                                                   [ 51%]
adalflow/tests/test_groq_client.py ..                                                                                          [ 52%]
adalflow/tests/test_lancedb_retriver.py ........                                                                               [ 55%]
adalflow/tests/test_lazy_import.py ........                                                                                    [ 59%]
adalflow/tests/test_logger.py ......                                                                                           [ 61%]
adalflow/tests/test_memory.py ...                                                                                              [ 63%]
adalflow/tests/test_model_client.py ...                                                                                        [ 64%]
adalflow/tests/test_ollama_client.py ..                                                                                        [ 65%]
adalflow/tests/test_openai_client.py ..                                                                                        [ 66%]
adalflow/tests/test_output_parser.py ......                                                                                    [ 68%]
adalflow/tests/test_parameter.py ............                                                                                  [ 74%]
adalflow/tests/test_parameter_text_grad.py ...                                                                                 [ 75%]
adalflow/tests/test_random_sample.py .....                                                                                     [ 77%]
adalflow/tests/test_sequential.py ...............                                                                              [ 83%]
adalflow/tests/test_string_parser.py ..........................                                                                [ 95%]
adalflow/tests/test_text_splitter.py .........                                                                                 [ 99%]
adalflow/tests/test_tool.py ..                                                                                                 [100%]

========================================================== warnings summary ==========================================================
adalflow/tests/test_ollama_client.py::TestOllamaModelClient::test_ollama_embedding_client
adalflow/tests/test_ollama_client.py::TestOllamaModelClient::test_ollama_llm_client
  /home/AdalFlow/adalflow/adalflow/components/model_client/ollama_client.py:165: UserWarning: Better to provide host or set OLLAMA_HOST env variable. We will use the default host http://localhost:11434 for now.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= 230 passed, 2 skipped, 2 warnings in 3.75s =============================================

```

### Breaking Changes
As far as I can test, this PR does not introduce any breaking changes. Existing functionality for non-streaming cases remains unaffected.

---

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?

</details>

---