### PR TITLE
Don't init tokenizer when import TextSplitter

### DIFF
--- a/adalflow/adalflow/components/data_process/text_splitter.py
+++ b/adalflow/adalflow/components/data_process/text_splitter.py
@@ -43,7 +43,6 @@ SEPARATORS = {
 DEFAULT_CHUNK_SIZE = 800
 DEFAULT_CHUNK_OVERLAP = 200
 
-tokenizer = Tokenizer()
 
 
 class TextSplitter(Component):
@@ -155,6 +154,8 @@ class TextSplitter(Component):
         # Document(id=ca0af45b-4f88-49b5-97db-163da9868ea4, text='text. Even more text to ', meta_data=None, vector=[], parent_doc_id=doc1, order=1, score=None)
         # Document(id=e7b617b2-3927-4248-afce-ec0fc247ac8b, text='to illustrate.', meta_data=None, vector=[], parent_doc_id=doc1, order=2, score=None)
     """
+
+    tokenizer = Tokenizer()
 
     def __init__(
         self,
@@ -301,7 +302,7 @@ class TextSplitter(Component):
     def _split_text_into_units(self, text: str, separator: str) -> List[str]:
         """Split text based on the specified separator."""
         if self.split_by == "token":
-            splits = tokenizer.encode(text)
+            splits = TextSplitter.tokenizer.encode(text)
         else:
             splits = text.split(separator)
         log.info(f"Text split by '{separator}' into {len(splits)} parts.")
@@ -344,7 +345,7 @@ class TextSplitter(Component):
 
         if self.split_by == "token":
             # decode each chunk here
-            chunks = [tokenizer.decode(chunk) for chunk in chunks]
+            chunks = [TextSplitter.tokenizer.decode(chunk) for chunk in chunks]
 
         log.info(f"Merged into {len(chunks)} chunks.")
         return chunks


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #320 

Move `tokenizer` from package level to class level, so that when we import this package, `tokenizer` won't be initialized. So the unnecessary SSLCertVerificationError can be avoided. 

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?


</details>


<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
