### PR TITLE
Xai integration

### DIFF
--- a/adalflow/adalflow/__init__.py
+++ b/adalflow/adalflow/__init__.py
@@ -69,6 +69,7 @@ from adalflow.components.model_client import (
     CohereAPIClient,
     BedrockAPIClient,
     DeepSeekClient,
+    MistralClient,
 )
 
 # data pipeline
@@ -140,6 +141,7 @@ __all__ = [
     "GroqAPIClient",
     "DeepSeekClient",
     "OllamaClient",
+    "MistralClient",
     "TransformersClient",
     "AnthropicAPIClient",
     "CohereAPIClient",

--- a/adalflow/adalflow/components/model_client/__init__.py
+++ b/adalflow/adalflow/components/model_client/__init__.py
@@ -49,6 +49,11 @@ DeepSeekClient = LazyImport(
     "adalflow.components.model_client.deepseek_client.DeepSeekClient", None
 )
 
+MistralClient = LazyImport(
+    "adalflow.components.model_client.deepseek_client.DeepSeekClient",
+    OptionalPackages.MISTRAL,
+)
+
 GoogleGenAIClient = LazyImport(
     "adalflow.components.model_client.google_client.GoogleGenAIClient",
     OptionalPackages.GOOGLE_GENERATIVEAI,

--- a/adalflow/adalflow/components/model_client/mistral_client.py
+++ b/adalflow/adalflow/components/model_client/mistral_client.py
@@ -1,0 +1,198 @@
+import os
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from mistralai import Mistral
+from adalflow.core.model_client import ModelClient
+from adalflow.core.types import (
+    ModelType,
+    CompletionUsage,
+    GeneratorOutput,
+    EmbedderOutput,
+)
+
+log = logging.getLogger(__name__)
+
+
+class MistralClient(ModelClient):
+    """
+    A simple synchronous Mistral client without streaming.
+
+    This class implements the minimal required methods for an AdalFlow ModelClient:
+      1. __init__, which initializes the sync client.
+      2. convert_inputs_to_api_kwargs, which converts AdalFlow inputs to Mistral's format.
+      3. call, which calls Mistral's synchronous chat completion endpoint.
+      4. parse_chat_completion, which parses the LLM output into a GeneratorOutput.
+      5. track_completion_usage, which can attempt to read token usage (if Mistral returns it).
+      6. parse_embedding_response, which we haven’t implemented (Mistral does not offer embeddings yet).
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        chat_completion_parser: Callable[[Any], Any] = None,
+        input_type: str = "messages",
+        env_api_key_name: str = "MISTRAL_API_KEY",
+        **kwargs,
+    ):
+        """
+        Initialize the Mistral API client (synchronously).
+
+        :param api_key: Mistral API key (string). If None, reads from env variable MISTRAL_API_KEY.
+        :param chat_completion_parser: A custom parser function if you wish to parse Mistral output differently.
+        :param input_type: Whether your model input is "text" or "messages".
+        :param env_api_key_name: Name of the environment variable with the API key.
+        :param kwargs: Additional model config or other arguments (e.g., "model_kwargs").
+        """
+        super().__init__()
+
+        self.api_key = api_key or os.getenv(env_api_key_name)
+        if not self.api_key:
+            raise ValueError(
+                f"Mistral API key is missing. "
+                f"Provide it to MistralClient(...) or set {env_api_key_name}."
+            )
+
+        self.chat_completion_parser = chat_completion_parser or self.default_parser
+        self.input_type = input_type
+        self.model_kwargs = kwargs.get("model_kwargs", {})
+        self.sync_client = self.init_sync_client()
+
+    def init_sync_client(self) -> Mistral:
+        """Initialize a synchronous Mistral client from the official `mistralai` package."""
+        return Mistral(api_key=self.api_key)
+
+    def convert_inputs_to_api_kwargs(
+        self,
+        input: Optional[Any] = None,
+        model_kwargs: Dict = {},
+        model_type: ModelType = ModelType.UNDEFINED,
+    ) -> Dict:
+        """
+        Convert AdalFlow inputs into the arguments that Mistral’s .chat.complete(...) expects.
+
+        For an LLM: we supply a list of `messages=[{"role": "...", "content": "..."}]`.
+        """
+        if model_type != ModelType.LLM:
+            raise ValueError(
+                f"MistralClient only supports ModelType.LLM in this example. Got {
+                    model_type}."
+            )
+
+        final_kwargs = dict(model_kwargs)
+
+        if self.input_type == "messages":
+            if isinstance(input, list):
+                messages = input
+            elif isinstance(input, str):
+                messages = [{"role": "user", "content": input}]
+            else:
+                raise TypeError(
+                    "Input must be str or list of {role, content} dictionaries."
+                )
+        elif self.input_type == "text":
+            if not isinstance(input, str):
+                raise TypeError("Input must be str when input_type == 'text'.")
+            messages = [{"role": "user", "content": input}]
+        else:
+            raise ValueError(f"Unsupported input_type: {self.input_type}")
+
+        final_kwargs["messages"] = messages
+        final_kwargs["model"] = final_kwargs.get("model", "mistral-large-latest")
+
+        return final_kwargs
+
+    def call(
+        self, api_kwargs: Dict = {}, model_type: ModelType = ModelType.UNDEFINED
+    ) -> GeneratorOutput:
+        """
+        Make a synchronous chat-completion call to Mistral’s `chat.complete(...)`.
+        Return a GeneratorOutput (the standard AdalFlow response for LLMs).
+        """
+        if model_type != ModelType.LLM:
+            raise ValueError("MistralClient only supports LLM calls in this example.")
+
+        try:
+            response = self.sync_client.chat.complete(**api_kwargs)
+            return self.parse_chat_completion(response)
+
+        except Exception as e:
+            log.error(f"Mistral call failed: {e}")
+            raise
+
+    def parse_chat_completion(self, completion: Any) -> GeneratorOutput:
+        """
+        Convert the raw Mistral completion into a standard GeneratorOutput.
+        """
+        try:
+            content = completion.choices[0].message.content
+        except Exception as exc:
+            log.error(f"Error extracting content from Mistral completion: {exc}")
+            return GeneratorOutput(data=None, error=str(exc), raw_response=completion)
+
+        usage = self.track_completion_usage(completion)
+
+        return GeneratorOutput(data=content, raw_response=completion, usage=usage)
+
+    def track_completion_usage(self, completion: Any) -> CompletionUsage:
+        """
+        Attempt to parse Mistral’s token usage from `completion.usage`.
+        If it’s missing, just return zero usage.
+        """
+        try:
+            usage_obj = completion.usage
+            return CompletionUsage(
+                completion_tokens=usage_obj.completion_tokens,
+                prompt_tokens=usage_obj.prompt_tokens,
+                total_tokens=usage_obj.total_tokens,
+            )
+        except (AttributeError, TypeError):
+            log.warning("No usage data in Mistral response.")
+            return CompletionUsage(0, 0, 0)
+
+    def parse_embedding_response(self, response: Any) -> EmbedderOutput:
+        """
+        Not implemented because Mistral doesn’t (yet) offer embeddings.
+        """
+        raise NotImplementedError("Embedding not supported by Mistral at this time.")
+
+    @staticmethod
+    def default_parser(completion: Any) -> str:
+        """
+        If you use a custom parser, you can pass it in the constructor.
+        Otherwise, we just pick out the text from the first choice.
+        """
+        try:
+            return completion.choices[0].message.content
+        except Exception as e:
+            log.error(f"Default parser failed: {e}")
+            return ""
+
+
+if __name__ == "__main__":
+    from adalflow.core import Generator
+    from adalflow.utils import get_logger
+    from dotenv import load_dotenv
+
+    log = get_logger(level="DEBUG")
+    load_dotenv()
+
+    mistral_client = MistralClient(
+        api_key=os.getenv("MISTRAL_API_KEY"),
+        input_type="text",
+        model_kwargs={"model": "mistral-large-latest"},
+    )
+
+    generator = Generator(
+        model_client=mistral_client,
+        model_kwargs={"model": "mistral-large-latest", "temperature": 0.7},
+    )
+
+    prompt_kwargs = {"input_str": "Explain the importance of the Fibonacci sequence."}
+
+    response = generator(prompt_kwargs)
+
+    if response.error:
+        print(f"Generator error: {response.error}")
+    else:
+        print(f"Mistral LLM output: {response.data}")

--- a/adalflow/adalflow/components/model_client/xai_client.py
+++ b/adalflow/adalflow/components/model_client/xai_client.py
@@ -1,0 +1,290 @@
+import httpx
+import logging
+
+from typing import Any, Dict, Optional, Sequence
+
+# AdalFlow imports -- adjust the import path if your repo structure differs
+from adalflow.core.model_client import ModelClient
+from adalflow.core.types import (
+    ModelType,
+    GeneratorOutput,
+    EmbedderOutput,
+    # Embedding,
+    # Usage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class XAIClient(ModelClient):
+    """
+    A ModelClient integration for xAI, making direct HTTP calls via httpx.
+
+    Follows the AdalFlow ModelClient protocol:
+    - init_sync_client
+    - init_async_client
+    - convert_inputs_to_api_kwargs
+    - call (sync)
+    - acall (async)
+    - parse_chat_completion
+    - parse_embedding_response (optional, if xAI or future endpoint supports embeddings)
+    """
+
+    BASE_URL = "https://api.x.ai/v1/chat/completions"
+
+    def __init__(
+        self,
+        api_key: str,
+        timeout: int = 30,
+        base_url: Optional[str] = None,
+    ):
+        """
+        Initialize the xAI model client.
+
+        Args:
+            api_key (str): Your xAI API key.
+            timeout (int): Default request timeout in seconds.
+            base_url (str, optional): Override the default base URL if needed.
+        """
+        super().__init__()
+        self.api_key = api_key
+        self.timeout = timeout
+        self.base_url = base_url or self.BASE_URL
+
+        # Initialize both sync and async clients
+        self.sync_client = self.init_sync_client()
+        self.async_client = self.init_async_client()
+
+    def init_sync_client(self) -> httpx.Client:
+        return httpx.Client(timeout=self.timeout)
+
+    def init_async_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self.timeout)
+
+    def convert_inputs_to_api_kwargs(
+        self,
+        input: Optional[Any] = None,
+        model_kwargs: Dict = {},
+        model_type: ModelType = ModelType.UNDEFINED,
+    ) -> Dict:
+        """
+        Convert AdalFlow inputs into the xAI API's request payload.
+
+        For LLM usage, we typically need:
+          {
+             "model": ...,
+             "messages": [ { "role": "user", "content": "Hello" }, ... ],
+             ...extra
+          }
+
+        Returns:
+            Dict: A dictionary of arguments that `call()` or `acall()` can pass to httpx.
+        """
+        final_args = dict(model_kwargs)  # copy so we don’t mutate original
+
+        if model_type == ModelType.LLM:
+            messages = []
+
+            if isinstance(input, str):
+                messages = [{"role": "user", "content": input}]
+            elif isinstance(input, Sequence):
+                messages = input
+            else:
+                raise ValueError(
+                    "For LLM usage, 'input' must be a string or list of messages."
+                )
+
+            final_args["messages"] = messages
+            return final_args
+
+        elif model_type == ModelType.EMBEDDER:
+            # If xAI eventually supports embeddings, adapt as needed
+            # For now, we either raise or do a placeholder
+            if isinstance(input, str):
+                input_list = [input]
+            elif isinstance(input, Sequence):
+                input_list = list(input)
+            else:
+                raise ValueError(
+                    "For EMBEDDER usage, 'input' must be a string or list of strings."
+                )
+
+            final_args["input"] = input_list
+            return final_args
+
+        else:
+            raise ValueError(f"model_type {model_type} is not supported by XAIClient.")
+
+    def call(self, api_kwargs: Dict = {}, model_type: ModelType = ModelType.UNDEFINED):
+        if not self.sync_client:
+            raise RuntimeError("Synchronous client not initialized.")
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        if model_type == ModelType.LLM:
+            model = api_kwargs.get("model")
+            if not model:
+                raise ValueError("Missing 'model' in api_kwargs for xAI LLM call.")
+
+            data = {
+                "model": model,
+                "messages": api_kwargs["messages"],
+            }
+
+            reserved_keys = {"model", "messages"}
+            for k, v in api_kwargs.items():
+                if k not in reserved_keys:
+                    data[k] = v
+
+            try:
+                response = self.sync_client.post(
+                    self.base_url,
+                    headers=headers,
+                    json=data,
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPError as exc:
+                logger.error(f"xAI sync call error: {exc}")
+                raise exc
+
+        elif model_type == ModelType.EMBEDDER:
+            raise NotImplementedError("xAI embeddings not yet implemented.")
+
+        else:
+            raise ValueError(f"Unsupported model_type {model_type}")
+
+    async def acall(
+        self, api_kwargs: Dict = {}, model_type: ModelType = ModelType.UNDEFINED
+    ):
+        """
+        Asynchronous call to xAI. We use httpx.AsyncClient to POST to the xAI endpoint.
+
+        Args:
+            api_kwargs (dict): The final request payload from convert_inputs_to_api_kwargs.
+            model_type (ModelType): LLM or EMBEDDER.
+
+        Returns:
+            dict: The raw JSON response from xAI.
+        """
+        if not self.async_client:
+            raise RuntimeError("Asynchronous client not initialized.")
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        if model_type == ModelType.LLM:
+            model = api_kwargs.get("model")
+            if not model:
+                raise ValueError("Missing 'model' in api_kwargs for xAI LLM call.")
+
+            data = {
+                "model": model,
+                "messages": api_kwargs["messages"],
+            }
+            reserved_keys = {"model", "messages"}
+            for k, v in api_kwargs.items():
+                if k not in reserved_keys:
+                    data[k] = v
+
+            try:
+                async with self.async_client as client:
+                    response = await client.post(
+                        self.base_url,
+                        headers=headers,
+                        json=data,
+                    )
+                    response.raise_for_status()
+                    return response.json()
+            except httpx.HTTPError as exc:
+                logger.error(f"xAI async call error: {exc}")
+                raise exc
+
+        elif model_type == ModelType.EMBEDDER:
+            raise NotImplementedError("xAI embeddings not yet implemented.")
+        else:
+            raise ValueError(f"Unsupported model_type {model_type}")
+
+    def parse_chat_completion(self, completion: Dict) -> GeneratorOutput:
+        """
+        Convert the raw xAI chat response into a GeneratorOutput for AdalFlow.
+
+        xAI’s typical JSON response might look something like:
+            {
+              "choices": [
+                {
+                  "message": {
+                    "role": "assistant",
+                    "content": "Hello there!"
+                  }
+                }
+              ]
+            }
+
+        Returns:
+            GeneratorOutput with the text from the first "assistant" message.
+        """
+        if not completion:
+            return GeneratorOutput(
+                data=None, error="Empty xAI response", raw_response=completion
+            )
+
+        try:
+            content = completion["choices"][0]["message"]["content"]
+            return GeneratorOutput(
+                data=content,
+                error=None,
+                raw_response=completion,
+            )
+        except (KeyError, IndexError) as e:
+            err_msg = f"Unexpected xAI response format: {e}"
+            logger.error(err_msg)
+            return GeneratorOutput(data=None, error=err_msg, raw_response=completion)
+
+    def parse_embedding_response(self, response: Dict) -> EmbedderOutput:
+        raise NotImplementedError("xAI embedding parse not yet implemented.")
+
+
+if __name__ == "__main__":
+    from adalflow.core import Generator
+    from adalflow.utils import get_logger
+    from dotenv import load_dotenv
+    import os
+
+    log = get_logger(level="DEBUG")
+    load_dotenv()
+
+    xai_api_key = os.getenv("XAI_API_KEY", "YOUR_XAI_API_KEY")
+
+    xai_client = XAIClient(api_key=xai_api_key, timeout=30)
+
+    generator = Generator(
+        model_client=xai_client,
+        model_kwargs={
+            "model": "grok-2-latest",
+            "temperature": 0,
+            "stream": False,
+        },
+    )
+
+    prompt_kwargs = {
+        "input": [
+            {"role": "system", "content": "You are a test assistant."},
+            {
+                "role": "user",
+                "content": "Testing. Just say hi and hello world and nothing else.",
+            },
+        ]
+    }
+
+    response = generator(prompt_kwargs)
+
+    if response.error:
+        print(f"[xAI] Generator Error: {response.error}")
+    else:
+        print(f"[xAI] Response: {response.data}")

--- a/adalflow/adalflow/utils/lazy_import.py
+++ b/adalflow/adalflow/utils/lazy_import.py
@@ -40,6 +40,7 @@ class OptionalPackages(Enum):
         from azure.identity import DefaultAzureCredential, get_bearer_token_provider
     """
     # model sdk
+    MISTRAL = ("mistralai", "Please install mistralai with: pip install mistralai")
     GROQ = ("groq", "Please install groq with: pip install groq")
     OPENAI = ("openai", "Please install openai with: pip install openai")
     ANTHROPIC = ("anthropic", "Please install anthropic with: pip install anthropic")


### PR DESCRIPTION
- Adds xAI's model client. This folows the same pattern of implementing the methods inherited form ModelClient. 

- Note that xAI did not have a model client that can be imported from installed package like other easier to integrate models had. 

- Instead it had to use httpx, which was consistent with the example that aisuite used as well.

- Rough around the edges and will likely need more code cleanup and testing.