### PR TITLE
Simplification of func_to_data_component

### DIFF
--- a/adalflow/adalflow/__init__.py
+++ b/adalflow/adalflow/__init__.py
@@ -3,10 +3,7 @@ __version__ = "1.0.3"
 from adalflow.core.component import (
     Component,
     DataComponent,
-    FuncComponent,
-    FuncDataComponent,
     func_to_data_component,
-    func_to_component,
 )
 from adalflow.core.container import Sequential, ComponentList
 from adalflow.core.base_data_class import DataClass, DataClassFormatType, required_field
@@ -79,10 +76,7 @@ from adalflow.components.data_process.data_components import ToEmbeddings
 __all__ = [
     "Component",
     "DataComponent",
-    "FuncComponent",
-    "FuncDataComponent",
     "func_to_data_component",
-    "func_to_component",
     # dataclass
     "DataClass",
     "DataClassFormatType",


### PR DESCRIPTION
This PR consolidates code for the decorator used to convert functions to `DataComponents`

**Reasons for Consolidation:**

Redundancy: The two decorators and their corresponding base classes (FuncComponent and FuncDataComponent) are almost identical. They serve the exact same purpose: to wrap a function and make it usable as an AdalFlow component. The only difference is the intended use case (general components vs. data-processing components).


**DataComponent is Sufficient:** The DataComponent base class already fulfills all the requirements. It inherits from Component, providing all the basic component functionality. It's designed for data processing, which is what your output_processors are doing. There's no functional reason to have a separate FuncComponent hierarchy.


**Simplicity:** Having two nearly identical sets of classes and decorators adds unnecessary complexity to the codebase. Consolidation makes the code easier to understand, maintain, and extend.