### PR TITLE
fix: update localDB to work with keyword-only arguments in several me…

### DIFF
--- a/adalflow/adalflow/core/db.py
+++ b/adalflow/adalflow/core/db.py
@@ -161,7 +161,7 @@ class LocalDB(Component):
     ) -> str:
         """Register a transformer to be used later for transforming the data."""
         if key is None:
-            key = self._get_transformer_name(transformer)
+            key = self._get_transformer_name(transformer=transformer)
             log.info(f"Generated key for transformer: {key}")
         self.transformer_setups[key] = transformer
         if map_fn is not None:
@@ -206,7 +206,7 @@ class LocalDB(Component):
         """
         key_to_use = key
         if transformer:
-            key = self.register_transformer(transformer, key, map_fn)
+            key = self.register_transformer(transformer=transformer, key=key, map_fn=map_fn)
             key_to_use = key
         if key_to_use is None:
             raise ValueError("Key must be provided.")

--- a/notebooks/tutorials/adalflow_rag_playbook.ipynb
+++ b/notebooks/tutorials/adalflow_rag_playbook.ipynb
@@ -172,7 +172,7 @@
     "    db = LocalDB()\n",
     "    db.load(docs)\n",
     "    data_transformer = prepare_data_pipeline()\n",
-    "    db.transform(data_transformer, key=\"data_transformer\")\n",
+    "    db.transform(transformer=data_transformer, key=\"data_transformer\")\n",
     "    db.save_state(index_path)"
    ]
   },


### PR DESCRIPTION
## What does this PR do?

In version 1.0.4, `LocalDB` is not working due to enforcing of keyword-only arguments using asterisks. 

The following internal methods will lead to error:

- `LocalDB()._get_transformer_name`
- `LocalDB().register_transformer`

While the following method will lead to an error in the tutorial notebook.

- `LocalDB().transform`

This PR:
- update the usage of the first 2 methods to use keyword-only arguments
- Update the tutorial notebook with correct `transform` method usage

Otherwise there should be no breaking change.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #375 

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs): _Yes._
- [X] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary): _Tutorial notebook is also updated accordingly._
- Did you write any **new necessary tests**? (not for typos and docs): _No_
- [X] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?: _Yes._


</details>


<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
