### PR TITLE
Fix mutable default args in OpenAI client

### DIFF
--- a/adalflow/adalflow/components/model_client/openai_client.py
+++ b/adalflow/adalflow/components/model_client/openai_client.py
@@ -402,7 +402,7 @@ class OpenAIClient(ModelClient):
     def convert_inputs_to_api_kwargs(
         self,
         input: Optional[Any] = None,
-        model_kwargs: Dict = {},
+        model_kwargs: Optional[Dict] = None,
         model_type: ModelType = ModelType.UNDEFINED,
     ) -> Dict:
         r"""
@@ -423,7 +423,7 @@ class OpenAIClient(ModelClient):
             Dict: API-specific kwargs for the model call
         """
 
-        final_model_kwargs = model_kwargs.copy()
+        final_model_kwargs = model_kwargs.copy() if model_kwargs else {}
         if model_type == ModelType.EMBEDDER:
             if isinstance(input, str):
                 input = [input]
@@ -494,7 +494,11 @@ class OpenAIClient(ModelClient):
         ),
         max_time=5,
     )
-    def call(self, api_kwargs: Dict = {}, model_type: ModelType = ModelType.UNDEFINED):
+    def call(
+        self,
+        api_kwargs: Optional[Dict] = None,
+        model_type: ModelType = ModelType.UNDEFINED,
+    ):
         """
         kwargs is the combined input and model_kwargs.  Support streaming call.
         For reasoning model, users can add "reasoning" key to the api_kwargs to pass the reasoning config.
@@ -507,6 +511,7 @@ class OpenAIClient(ModelClient):
             }
         }
         """
+        api_kwargs = api_kwargs or {}
         log.info(f"api_kwargs: {api_kwargs}")
         self._api_kwargs = api_kwargs
         if model_type == ModelType.EMBEDDER:
@@ -559,12 +564,15 @@ class OpenAIClient(ModelClient):
         max_time=5,
     )
     async def acall(
-        self, api_kwargs: Dict = {}, model_type: ModelType = ModelType.UNDEFINED
+        self,
+        api_kwargs: Optional[Dict] = None,
+        model_type: ModelType = ModelType.UNDEFINED,
     ):
         """
         kwargs is the combined input and model_kwargs
         """
         # store the api kwargs in the client
+        api_kwargs = api_kwargs or {}
         self._api_kwargs = api_kwargs
         if self.async_client is None:
             self.async_client = self.init_async_client()


### PR DESCRIPTION
## Summary
- fix mutable default arguments in OpenAIClient

## Testing
- `ruff check adalflow/adalflow/components/model_client/openai_client.py --fix`
- `black adalflow/adalflow/components/model_client/openai_client.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6859df114f188320b8ec69011867c7f3