### PR TITLE
Modified subclasses of RunItems to use data field of RunItem

### DIFF
--- a/adalflow/adalflow/components/model_client/chat_completion_to_response_converter.py
+++ b/adalflow/adalflow/components/model_client/chat_completion_to_response_converter.py
@@ -3,6 +3,7 @@ Code from OpenAI Agents library src/agents/models/openai_chatcompletions.py
 
 Used to convert the OpenAI ChatCompletion stream to Response API format
 """
+
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Iterator
@@ -63,7 +64,7 @@ class SequenceNumber:
 
 class ChatCompletionToResponseConverter:
     """Converts OpenAI ChatCompletion streams to standardized Response API format events."""
-    
+
     @classmethod
     async def async_handle_stream(
         cls,

--- a/adalflow/adalflow/core/runner.py
+++ b/adalflow/adalflow/core/runner.py
@@ -608,7 +608,7 @@ class Runner(Component):
                 printc(f"function: {function}", color="yellow")
 
                 # Emit tool call event
-                tool_call_item = ToolCallRunItem(function=function)
+                tool_call_item = ToolCallRunItem(data=function)
                 tool_call_event = RunItemStreamEvent(
                     name="agent.tool_call_start", item=tool_call_item
                 )
@@ -654,7 +654,7 @@ class Runner(Component):
                 self.step_history.append(step_output)
 
                 # Emit step completion event
-                step_item = StepRunItem(step_output=step_output)
+                step_item = StepRunItem(data=step_output)
                 step_event = RunItemStreamEvent(
                     name="agent.step_complete", item=step_item
                 )
@@ -677,9 +677,7 @@ class Runner(Component):
                     streaming_result._is_complete = True
 
                     # Emit execution complete event
-                    final_output_item = FinalOutputItem(
-                        runner_response=runner_response, final_output=processed_data
-                    )
+                    final_output_item = FinalOutputItem(data=runner_response)
                     final_output_event = RunItemStreamEvent(
                         name="agent.execution_complete", item=final_output_item
                     )
@@ -704,9 +702,7 @@ class Runner(Component):
                 streaming_result._is_complete = True
 
                 # Emit error as FinalOutputItem to queue
-                error_final_item = FinalOutputItem(
-                    runner_response=error_runner_response
-                )
+                error_final_item = FinalOutputItem(data=error_runner_response)
                 error_event = RunItemStreamEvent(
                     name="runner_finished", item=error_final_item
                 )

--- a/adalflow/adalflow/core/types.py
+++ b/adalflow/adalflow/core/types.py
@@ -1054,7 +1054,7 @@ class ToolCallRunItem(RunItem):
     what tools are being invoked and potentially intervene or log the calls.
 
     Attributes:
-        function: The Function object containing the tool call details (name, args, kwargs)
+        data: The Function object containing the tool call details (name, args, kwargs)
 
     Event Flow Position:
         1. Planner generates Function → **ToolCallRunItem** → Function execution → ToolOutputRunItem
@@ -1065,12 +1065,12 @@ class ToolCallRunItem(RunItem):
         async for event in runner.astream(prompt_kwargs).stream_events():
             if isinstance(event, RunItemStreamEvent) and event.name == "tool_called":
                 tool_call_item = event.item
-                print(f"About to call: {tool_call_item.function.name}")
+                print(f"About to call: {tool_call_item.data.name}")
         ```
     """
 
     type: str = field(default="tool_call", metadata={"desc": "Type of run item"})
-    function: Optional[Function] = field(
+    data: Optional[Function] = field(
         default=None,
         metadata={"desc": "Function object containing the tool call to be executed"},
     )
@@ -1086,7 +1086,7 @@ class ToolOutputRunItem(RunItem):
     notification to the caller.
 
     Attributes:
-        function_output: Complete FunctionOutput containing execution results, errors, etc.
+        data: Complete FunctionOutput containing execution results, errors, etc.
 
     Event Flow Position:
         ToolCallRunItem → Function execution → **ToolOutputRunItem** → StepRunItem
@@ -1097,15 +1097,15 @@ class ToolOutputRunItem(RunItem):
         async for event in runner.astream(prompt_kwargs).stream_events():
             if isinstance(event, RunItemStreamEvent) and event.name == "tool_output":
                 output_item = event.item
-                if output_item.function_output.error:
-                    print(f"Function failed: {output_item.function_output.error}")
+                if output_item.data.error:
+                    print(f"Function failed: {output_item.data.error}")
                 else:
-                    print(f"Function result: {output_item.function_output.output}")
+                    print(f"Function result: {output_item.data.output}")
         ```
     """
 
     type: str = field(default="tool_output", metadata={"desc": "Type of run item"})
-    function_output: Optional[FunctionOutput] = field(
+    data: Optional[FunctionOutput] = field(
         default=None,
         metadata={
             "desc": "Complete function execution result including output and error status"
@@ -1123,7 +1123,7 @@ class StepRunItem(RunItem):
     including the action taken and the observation (result).
 
     Attributes:
-        step_output: Complete StepOutput containing step number, action, and observation
+        data: Complete StepOutput containing step number, action, and observation
 
     Event Flow Position:
         ToolOutputRunItem → **StepRunItem** → (next step or completion)
@@ -1134,12 +1134,12 @@ class StepRunItem(RunItem):
         async for event in runner.astream(prompt_kwargs).stream_events():
             if isinstance(event, RunItemStreamEvent) and event.name == "step_completed":
                 step_item = event.item
-                print(f"Completed step {step_item.step_output.step}")
+                print(f"Completed step {step_item.data.step}")
         ```
     """
 
     type: str = field(default="step", metadata={"desc": "Type of run item"})
-    step_output: Optional[StepOutput] = field(
+    data: Optional[StepOutput] = field(
         default=None,
         metadata={
             "desc": "Complete step execution result including action and observation"
@@ -1156,9 +1156,8 @@ class FinalOutputItem(RunItem):
     processed result. It's emitted regardless of whether execution completed
     successfully or with an error.
 
-    There are two ways you can store the final output:
-    - runner_response: The final RunnerResponse containing the complete execution result
-    - final_output: The final processed output from the runner execution
+    Attributes:
+        data: The final RunnerResponse containing the complete execution result
 
     Event Flow Position:
         Final step → **FinalOutputItem** (execution complete)
@@ -1169,21 +1168,17 @@ class FinalOutputItem(RunItem):
         async for event in runner.astream(prompt_kwargs).stream_events():
             if isinstance(event, RunItemStreamEvent) and event.name == "runner_finished":
                 final_item = event.item
-                if final_item.runner_response.error:
-                    print(f"Execution failed: {final_item.runner_response.error}")
+                if final_item.data.error:
+                    print(f"Execution failed: {final_item.data.error}")
                 else:
-                    print(f"Final answer: {final_item.runner_response.answer}")
+                    print(f"Final answer: {final_item.data.answer}")
         ```
     """
 
     type: str = field(default="final_output", metadata={"desc": "Type of run item"})
-    runner_response: Optional["RunnerResponse"] = field(
+    data: Optional["RunnerResponse"] = field(
         default=None,
         metadata={"desc": "Final execution result wrapped in RunnerResponse"},
-    )
-    final_output: Optional[Any] = field(
-        default=None,
-        metadata={"desc": "Final processed output from the runner execution"},
     )
 
 

--- a/adalflow/tests/test_runner.py
+++ b/adalflow/tests/test_runner.py
@@ -238,7 +238,7 @@ class TestRunner(unittest.TestCase):
 
             # Verify the event contains FinalOutputItem with RunnerResponse
             self.assertIsInstance(final_event.item, FinalOutputItem)
-            runner_response = final_event.item.runner_response
+            runner_response = final_event.item.data
             self.assertIsInstance(runner_response, RunnerResponse)
             self.assertEqual(runner_response.answer, "stream-done")
             # function_call field removed from RunnerResponse
@@ -481,8 +481,8 @@ class TestRunner(unittest.TestCase):
 
             final_event = final_events[0]
             self.assertIsInstance(final_event.item, FinalOutputItem)
-            self.assertIsInstance(final_event.item.runner_response, RunnerResponse)
-            self.assertEqual(final_event.item.runner_response.answer, "stream-test")
+            self.assertIsInstance(final_event.item.data, RunnerResponse)
+            self.assertEqual(final_event.item.data.answer, "stream-test")
 
         asyncio.run(async_test())
 

--- a/tutorials/v1_agent_runner/anthropic_streaming_tutorial.py
+++ b/tutorials/v1_agent_runner/anthropic_streaming_tutorial.py
@@ -33,11 +33,13 @@ from adalflow.core.func_tool import FunctionTool
 from adalflow.core.base_data_class import DataClass
 from dataclasses import dataclass
 
+from adalflow.utils.lazy_import import setup_env
+
 # Direct Anthropic API imports
 import anthropic
 
 
-# setup_env()  # Comment out to prevent FileNotFoundError when .env doesn't exist
+setup_env()  # Comment out to prevent FileNotFoundError when .env doesn't exist
 
 
 def demonstrate_direct_anthropic_streaming():

--- a/tutorials/v1_agent_runner/anthropic_streaming_tutorial.py
+++ b/tutorials/v1_agent_runner/anthropic_streaming_tutorial.py
@@ -36,8 +36,8 @@ from dataclasses import dataclass
 # Direct Anthropic API imports
 import anthropic
 
-from adalflow.utils import setup_env
-setup_env()
+
+# setup_env()  # Comment out to prevent FileNotFoundError when .env doesn't exist
 
 
 def demonstrate_direct_anthropic_streaming():

--- a/tutorials/v1_agent_runner/example_runner_streaming.py
+++ b/tutorials/v1_agent_runner/example_runner_streaming.py
@@ -241,17 +241,15 @@ async def test_runner_streaming():
                 print(f"⚡ Run Item Event: {event.name}")
                 if hasattr(event, "item") and event.item:
                     if isinstance(event.item, FinalOutputItem):
+                        print(f"   Final Output - Answer: {event.item.data.answer}")
                         print(
-                            f"   Final Output - Answer: {event.item.runner_response.answer}"
-                        )
-                        print(
-                            f"   Final Output - Step History Length: {len(event.item.runner_response.step_history) if event.item.runner_response.step_history else 0}"
+                            f"   Final Output - Step History Length: {len(event.item.data.step_history) if event.item.data.step_history else 0}"
                         )
                         if (
-                            event.item.runner_response.step_history
-                            and len(event.item.runner_response.step_history) > 0
+                            event.item.data.step_history
+                            and len(event.item.data.step_history) > 0
                         ):
-                            last_step = event.item.runner_response.step_history[-1]
+                            last_step = event.item.data.step_history[-1]
                             print(
                                 f"   Final Output - Last Function: {last_step.function}"
                             )
@@ -334,17 +332,15 @@ async def test_runner_streaming_nested():
                 print(f"⚡ Run Item Event: {event.name}")
                 if hasattr(event, "item") and event.item:
                     if isinstance(event.item, FinalOutputItem):
+                        print(f"   Final Output - Answer: {event.item.data.answer}")
                         print(
-                            f"   Final Output - Answer: {event.item.runner_response.answer}"
-                        )
-                        print(
-                            f"   Final Output - Step History Length: {len(event.item.runner_response.step_history) if event.item.runner_response.step_history else 0}"
+                            f"   Final Output - Step History Length: {len(event.item.data.step_history) if event.item.data.step_history else 0}"
                         )
                         if (
-                            event.item.runner_response.step_history
-                            and len(event.item.runner_response.step_history) > 0
+                            event.item.data.step_history
+                            and len(event.item.data.step_history) > 0
                         ):
-                            last_step = event.item.runner_response.step_history[-1]
+                            last_step = event.item.data.step_history[-1]
                             print(
                                 f"   Final Output - Last Function: {last_step.function}"
                             )


### PR DESCRIPTION
## What does this PR do?

This PR standardizes RunItem types to stores its relevant data or output in the data field which is inherited by the RunItem class. 

- Updated the Runner component and related tests/tutorials to use the new standardized data field structure from types.py, replacing specific named fields with a consistent interface using the data field across all RunItem subclasses.
- Updated the subclasses of RunItems, ToolCallRunItem, StepRunItem, FinalOutputItem to use the data field of RunItem to store data. 

## Breaking changes? 
The caller of the Runner streamed method will now refer to the updated RunItem subclass types and their documentations. 

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request? 

</details>


<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
