### PR TITLE
Release for version 1.05a1 

### DIFF
--- a/adalflow/adalflow/__init__.py
+++ b/adalflow/adalflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.4"
+__version__ = "1.0.5a1"
 
 from adalflow.core.component import (
     Component,

--- a/adalflow/adalflow/core/agent.py
+++ b/adalflow/adalflow/core/agent.py
@@ -244,21 +244,29 @@ def create_default_planner(
 
 
 class Agent(Component):
-    """
-    An agent is a high-level component that holds (1) a generator as task plannaer (calling tools) and (2) a tool manager to manage tools.
+    """A high-level agentic component that orchestrates AI planning and tool execution.
 
-    It comes with default prompt template that instructs LLM (1) agentic task description (2) template on adding definitions of tools
-    (3) arguments to fill in history.
+    The Agent combines a Generator-based planner for task decomposition with a ToolManager
+    for function calling. It uses a ReAct (Reasoning and Acting) architecture to iteratively
+    plan steps and execute tools to solve complex tasks.
 
-    Additionally, it comes with two helper tools:
-    1. finish: to finish the task
-    2. additional_llm_tool: to answer any input query with llm's world knowledge. Use me as a fallback tool or when the query is simple.
+    The Agent comes with default prompt templates for agentic reasoning, automatic tool
+    definition integration, and step history tracking. It includes built-in helper tools:
+    - finish: Terminates execution with the final answer
+    - llm_tool: Fallback tool using LLM world knowledge for simple queries
+
+    Architecture:
+        Agent contains two main components:
+        1. Planner (Generator): Plans and reasons about next actions using an LLM
+        2. ToolManager: Manages and executes available tools/functions
 
     Attributes:
-        name (str): Name of the agent
-        tool_manager (ToolManager): Stores and manages tools
-        generator (Generator): Handles text generation with a language model
-        the output_processors must return the type StepOutput
+        name (str): Unique identifier for the agent instance
+        tool_manager (ToolManager): Manages available tools and their execution
+        planner (Generator): LLM-based planner for task decomposition and reasoning
+        answer_data_type (Type): Expected type for the final answer output
+        max_steps (int): Maximum number of planning steps allowed
+        is_thinking_model (bool): Whether the underlying model supports chain-of-thought
     """
 
     def __init__(

--- a/adalflow/adalflow/core/generator.py
+++ b/adalflow/adalflow/core/generator.py
@@ -496,8 +496,8 @@ class Generator(GradComponent, CachedEngine, CallbackManager):
             completion = self.model_client.call(
                 api_kwargs=api_kwargs, model_type=self.model_type
             )
-            # prepare cache
-            if use_cache:
+            # prepare cache - skip caching for streaming responses which contain unpickleable threading objects
+            if use_cache and not api_kwargs.get("stream", False):
                 self._save_cache(index_content, completion)
             return completion
         except Exception as e:
@@ -521,8 +521,8 @@ class Generator(GradComponent, CachedEngine, CallbackManager):
             completion = await self.model_client.acall(
                 api_kwargs=api_kwargs, model_type=self.model_type
             )
-            # save to cache
-            if use_cache:
+            # save to cache - skip caching for streaming responses which contain unpickleable threading objects
+            if use_cache and not api_kwargs.get("stream", False):
                 self._save_cache(index_content, completion)
             return completion
         except Exception as e:

--- a/adalflow/adalflow/core/runner.py
+++ b/adalflow/adalflow/core/runner.py
@@ -62,19 +62,32 @@ AdalflowDataClass: TypeAlias = Type[
 
 
 class Runner(Component):
-    """A runner class that executes an Agent instance with multi-step execution.
+    """Executes Agent instances with multi-step iterative planning and tool execution.
 
-    It internally maintains a planner LLM and an executor and adds a LLM call to the executor as a tool for the planner.
+    The Runner orchestrates the execution of an Agent through multiple reasoning and action
+    cycles. It manages the step-by-step execution loop where the Agent's planner generates
+    Function calls that get executed by the ToolManager, with results fed back into the
+    planning context for the next iteration.
 
-    The output to the planner agent  call is expected to be a Function object. The planner iterates through at most
-    max_steps unless the planner sets the action to "finish" then the planner returns the final response.
+    Execution Flow:
+        1. Initialize step history and prompt context
+        2. For each step (up to max_steps):
+           a. Call Agent's planner to get next Function
+           b. Execute the Function using ToolManager
+           c. Add step result to history
+           d. Check if Function is "finish" to terminate
+        3. Process final answer to expected output type
 
-    If the user optionally specifies the output_type then the Runner parses the Function object to the output_type.
+    The Runner supports both synchronous and asynchronous execution modes, as well as
+    streaming execution with real-time event emission. It includes comprehensive tracing
+    and error handling throughout the execution pipeline.
 
     Attributes:
-        planner (Agent): The agent instance to execute
-        config (RunnerConfig): Configuration for the runner
-        max_steps (int): Maximum number of steps to execute
+        agent (Agent): The Agent instance to execute
+        max_steps (int): Maximum number of execution steps allowed
+        answer_data_type (Type): Expected type for final answer processing
+        step_history (List[StepOutput]): History of all execution steps
+        ctx (Optional[Dict]): Additional context passed to tools
     """
 
     def __init__(

--- a/adalflow/pyproject.toml
+++ b/adalflow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "adalflow"
-version = "1.0.4"
+version = "1.0.5a1"
 description = "The Library to Build and Auto-optimize LLM Applications"
 authors = ["Li Yin <li@sylphai.com>"]
 readme = "README.md"

--- a/tutorials/v1_agent_runner/agent_runner.py
+++ b/tutorials/v1_agent_runner/agent_runner.py
@@ -722,14 +722,14 @@ if __name__ == "__main__":
     # Define all examples to run
     examples = [
         ("Synchronous ReAct Agent", run_react_agent_example),
-        # ("Primitive Type ReAct Agent", run_react_agent_primitive_type),
-        # ("Async ReAct Agent", lambda: asyncio.run(arun_react_agent_example())),
-        # ("Advanced ReAct Agent", run_advanced_react_agent),
+        ("Primitive Type ReAct Agent", run_react_agent_primitive_type),
+        ("Async ReAct Agent", lambda: asyncio.run(arun_react_agent_example())),
+        ("Advanced ReAct Agent", run_advanced_react_agent),
         (
             "Advanced Async ReAct Agent",
             lambda: asyncio.run(arun_advanced_react_agent()),
         ),
-        # ("No Structured Output Agent", no_structured_output_run_agent),
+        ("No Structured Output Agent", no_structured_output_run_agent),
         ("Pydantic Dataclass Agent", pydantic_dataclass_run_agent),
     ]
 


### PR DESCRIPTION
## What does this PR do?

  Major Features for Release 1.05a1

  • New agent interface - initializes, when not provided, a default planner / generator and ToolManager and uses them 

  • New runner interface - it supports executing multi-step reasoning before generating an answer similar to that of the ReAct agent, supports  synchronous/asynchronous calls, supports streaming of structured and non-structured outputs, and integrates tracing to visualize each of the Runner's steps and also actions taken within each step 

  • Implement structured output processing - Support Pydantic dataclasses, AdalFlow dataclasses, and built-in Python types  with parsing handled before returning to the user

  • Integrate OpenAI-compatible tracing system - founded upon OpenAI Agent library's tracing provider, allowing integrations with visualization libraries that support OpenAI's tracing provider such as MLflow 

  • MCP (Model Context Protocol) tools - Connect external tool servers via stdio, SSE, and HTTP protocols with dynamic tool discovery and standardized function calling interfaces

  • newer Generator output structures - supports a model-agnostic raw_response field which converts model clients' api responses into the OpenAI API raw response format 


<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you verify new and **existing tests pass** locally with your changes?


</details>

