### PR TITLE
fix: MLflow 3.7+ compatibility - graceful handling of removed agent tracer

### DIFF
--- a/adalflow/adalflow/tracing/mlflow_integration.py
+++ b/adalflow/adalflow/tracing/mlflow_integration.py
@@ -12,12 +12,21 @@ log = logging.getLogger(__name__)
 try:
     # Do NOT set ADALFLOW_DISABLE_TRACING here - it should be set before imports
     import mlflow
-    # BUG: This import is not working for mlflow 3.7.0
-    from mlflow.openai._agent_tracer import MlflowOpenAgentTracingProcessor
-
     MLFLOW_AVAILABLE = True
+    
+    # Try importing the agent tracer (may not exist in newer MLflow versions)
+    try:
+        from mlflow.openai._agent_tracer import MlflowOpenAgentTracingProcessor
+        MLFLOW_AGENT_TRACER_AVAILABLE = True
+    except (ImportError, AttributeError):
+        MLFLOW_AGENT_TRACER_AVAILABLE = False
+        log.debug("MLflow agent tracer not available in this MLflow version")
+        MlflowOpenAgentTracingProcessor = None
+        
 except ImportError:
     MLFLOW_AVAILABLE = False
+    MLFLOW_AGENT_TRACER_AVAILABLE = False
+    MlflowOpenAgentTracingProcessor = None
     log.warning("MLflow not available. Install with: pip install mlflow")
 
 
@@ -68,6 +77,14 @@ def enable_mlflow_local(
 
     if not MLFLOW_AVAILABLE:
         log.error("MLflow is not installed. Cannot enable MLflow tracing.")
+        return False
+    
+    if not MLFLOW_AGENT_TRACER_AVAILABLE:
+        log.error(
+            "MLflow agent tracer is not available in this MLflow version. "
+            "This feature requires MLflow < 3.7.0. Please downgrade MLflow or "
+            "use an alternative tracing method."
+        )
         return False
 
     try:
@@ -147,6 +164,14 @@ def enable_mlflow_local_with_server(
 
     if not MLFLOW_AVAILABLE:
         log.error("MLflow is not installed. Cannot enable MLflow tracing.")
+        return False
+    
+    if not MLFLOW_AGENT_TRACER_AVAILABLE:
+        log.error(
+            "MLflow agent tracer is not available in this MLflow version. "
+            "This feature requires MLflow < 3.7.0. Please downgrade MLflow or "
+            "use an alternative tracing method."
+        )
         return False
 
     try:


### PR DESCRIPTION
Fixes #459

## Problem

The `mlflow.openai._agent_tracer` module was removed or relocated in MLflow 3.7.0, causing import failures when users try to run the quickstart example from the documentation.

## Solution

This PR adds graceful handling for the missing module:

- Added `MLFLOW_AGENT_TRACER_AVAILABLE` flag to check tracer availability separately from MLflow itself
- Changed hard import failure to a soft warning with `None` fallback
- Added clear error messages in `enable_mlflow_local()` and `enable_mlflow_local_with_server()` directing users to either:
  - Downgrade MLflow to < 3.7.0, or
  - Use an alternative tracing method

## Changes

- Modified `adalflow/tracing/mlflow_integration.py` to handle the missing import gracefully
- Added validation checks before attempting to use `MlflowOpenAgentTracingProcessor`
- Improved error messages for better user experience

## Testing

The library now loads successfully with MLflow 3.7+, and provides actionable error messages when tracing features are attempted.

## Related

This ensures the AdalFlow library can coexist with newer MLflow versions without breaking imports, while maintaining backwards compatibility for users with older MLflow installations.