### PR TITLE
481 strip frequency penalty

### DIFF
--- a/adalflow/adalflow/components/model_client/openai_client.py
+++ b/adalflow/adalflow/components/model_client/openai_client.py
@@ -409,6 +409,9 @@ def handle_streaming_response_sync(stream: Iterable) -> GeneratorType:
 
 
 class OpenAIClient(ModelClient):
+    _REASONING_MODEL_PREFIXES = ("o1", "o3", "o4", "gpt-5")
+    _UNSUPPORTED_REASONING_KWARGS = ("frequency_penalty",)
+
     __doc__ = r"""A component wrapper for the OpenAI API client.
 
     Support both embedding and response API, including multimodal capabilities.
@@ -978,6 +981,34 @@ class OpenAIClient(ModelClient):
             raise ValueError(f"model_type {model_type} is not supported")
         return final_model_kwargs
 
+    def _strip_unsupported_reasoning_kwargs(self, api_kwargs: Dict) -> Dict:
+        """Return a copy of api_kwargs with unsupported reasoning-model params removed.
+
+        Checks whether the request targets a reasoning model by inspecting the
+        ``model`` key against ``_REASONING_MODEL_PREFIXES``, then drops any keys
+        listed in ``_UNSUPPORTED_REASONING_KWARGS``.
+        """
+        model: str = api_kwargs.get("model", "")
+        is_reasoning = any(
+            model.startswith(prefix) for prefix in self._REASONING_MODEL_PREFIXES
+        )
+        if not is_reasoning:
+            return api_kwargs
+
+        cleaned = {
+            k: v
+            for k, v in api_kwargs.items()
+            if k not in self._UNSUPPORTED_REASONING_KWARGS
+        }
+        stripped = [k for k in api_kwargs if k not in cleaned]
+        if stripped:
+            log.debug(
+                "Stripped unsupported kwargs for reasoning model '%s': %s",
+                model,
+                stripped,
+            )
+        return cleaned
+
     def parse_image_generation_response(self, response: List[Image]) -> GeneratorOutput:
         """Parse the image generation response into a GeneratorOutput."""
         try:
@@ -1032,6 +1063,7 @@ class OpenAIClient(ModelClient):
         #         self.chat_completion_parser = self.non_streaming_chat_completion_parser
         #         return self.sync_client.chat.completions.create(**api_kwargs)
         elif model_type == ModelType.LLM_REASONING or model_type == ModelType.LLM:
+            api_kwargs = self._strip_unsupported_reasoning_kwargs(api_kwargs)
             if "stream" in api_kwargs and api_kwargs.get("stream", False):
                 log.debug("streaming call")
                 self.response_parser = (
@@ -1087,6 +1119,7 @@ class OpenAIClient(ModelClient):
         #         # setting response parser as async non-streaming parser for Response API
         #         return await self.async_client.responses.create(**api_kwargs)
         elif model_type == ModelType.LLM or model_type == ModelType.LLM_REASONING:
+            api_kwargs = self._strip_unsupported_reasoning_kwargs(api_kwargs)
             if "stream" in api_kwargs and api_kwargs.get("stream", False):
                 log.debug("async streaming call")
                 self.response_parser = (

--- a/adalflow/adalflow/components/model_client/openai_client.py
+++ b/adalflow/adalflow/components/model_client/openai_client.py
@@ -25,7 +25,6 @@ import backoff
 # optional import
 from adalflow.utils.lazy_import import safe_import, OptionalPackages
 
-
 openai = safe_import(OptionalPackages.OPENAI.value[0], OptionalPackages.OPENAI.value[1])
 
 from openai import (
@@ -83,6 +82,7 @@ class ParsedResponseContent:
         code_outputs: Outputs from code interpreter
         raw_output: The original output array for advanced processing
     """
+
     text: Optional[str] = None
     images: Optional[Union[str, List[str]]] = None
     tool_calls: Optional[List[Dict[str, Any]]] = None
@@ -92,13 +92,9 @@ class ParsedResponseContent:
 
     def __bool__(self) -> bool:
         """Check if there's any content."""
-        return any([
-            self.text,
-            self.images,
-            self.tool_calls,
-            self.reasoning,
-            self.code_outputs
-        ])
+        return any(
+            [self.text, self.images, self.tool_calls, self.reasoning, self.code_outputs]
+        )
 
 
 # OLD CHAT COMPLETION PARSING FUNCTIONS (COMMENTED OUT)
@@ -135,14 +131,14 @@ def parse_response_output(response: Response) -> ParsedResponseContent:
     content = ParsedResponseContent()
 
     # Store raw output for advanced users
-    if hasattr(response, 'output'):
+    if hasattr(response, "output"):
         content.raw_output = response.output
 
     # First try to use output_text if available (SDK convenience property)
-    if hasattr(response, 'output_text') and response.output_text:
+    if hasattr(response, "output_text") and response.output_text:
         content.text = response.output_text
     # Parse the output array manually if no output_text
-    if hasattr(response, 'output') and response.output:
+    if hasattr(response, "output") and response.output:
         parsed = _parse_output_array(response.output)
         content.text = content.text or parsed.get("text")
         content.images = parsed.get("images", [])
@@ -151,7 +147,6 @@ def parse_response_output(response: Response) -> ParsedResponseContent:
         content.code_outputs = parsed.get("code_outputs")
 
     return content
-
 
 
 def _parse_message(item) -> Dict[str, Any]:
@@ -165,19 +160,21 @@ def _parse_message(item) -> Dict[str, Any]:
     """
     result = {"text": None}
 
-    if hasattr(item, 'content') and isinstance(item.content, list):
-        # now pick the longer response 
+    if hasattr(item, "content") and isinstance(item.content, list):
+        # now pick the longer response
         text_parts = []
 
         for content_item in item.content:
-            content_type = getattr(content_item, 'type', None)
+            content_type = getattr(content_item, "type", None)
 
             if content_type == "output_text":
-                if hasattr(content_item, 'text'):
+                if hasattr(content_item, "text"):
                     text_parts.append(content_item.text)
 
         if text_parts:
-            result["text"] = max(text_parts, key=len) if len(text_parts) > 1 else text_parts[0]
+            result["text"] = (
+                max(text_parts, key=len) if len(text_parts) > 1 else text_parts[0]
+            )
 
     return result
 
@@ -194,11 +191,11 @@ def _parse_reasoning(item) -> Dict[str, Any]:
     result = {"reasoning": None}
 
     # Extract text from reasoning summary if available
-    if hasattr(item, 'summary') and isinstance(item.summary, list):
+    if hasattr(item, "summary") and isinstance(item.summary, list):
         summary_texts = []
         for summary_item in item.summary:
-            if hasattr(summary_item, 'type') and summary_item.type == "summary_text":
-                if hasattr(summary_item, 'text'):
+            if hasattr(summary_item, "type") and summary_item.type == "summary_text":
+                if hasattr(summary_item, "text"):
                     summary_texts.append(summary_item.text)
 
         if summary_texts:
@@ -219,7 +216,7 @@ def _parse_image(item) -> Dict[str, Any]:
     """
     result = {"images": None}
 
-    if hasattr(item, 'result'):
+    if hasattr(item, "result"):
         # The result contains the base64 image data or URL
         result["images"] = item.result
 
@@ -235,23 +232,18 @@ def _parse_tool_call(item) -> Dict[str, Any]:
     Returns:
         Dict with tool call information
     """
-    item_type = getattr(item, 'type', None)
+    item_type = getattr(item, "type", None)
 
     if item_type == "image_generation_call":
         # Handle image generation - extract the result which contains the image data
-        if hasattr(item, 'result'):
+        if hasattr(item, "result"):
             # The result contains the base64 image data or URL
             return {"images": item.result}
     elif item_type == "code_interpreter_tool_call":
         return {"code_outputs": [_serialize_item(item)]}
     else:
         # Generic tool call
-        return {
-            "tool_calls": [{
-                "type": item_type,
-                "content": _serialize_item(item)
-            }]
-        }
+        return {"tool_calls": [{"type": item_type, "content": _serialize_item(item)}]}
 
     return {}
 
@@ -272,7 +264,7 @@ def _parse_output_array(output_array) -> Dict[str, Any]:
         "images": None,
         "tool_calls": None,
         "reasoning": None,
-        "code_outputs": None
+        "code_outputs": None,
     }
 
     if not output_array:
@@ -286,7 +278,7 @@ def _parse_output_array(output_array) -> Dict[str, Any]:
     text = None
 
     for item in output_array:
-        item_type = getattr(item, 'type', None)
+        item_type = getattr(item, "type", None)
 
         if item_type == "reasoning":
             # Parse reasoning item
@@ -306,7 +298,7 @@ def _parse_output_array(output_array) -> Dict[str, Any]:
             if parsed.get("images"):
                 all_images.append(parsed["images"])
 
-        elif item_type and ('call' in item_type or 'tool' in item_type):
+        elif item_type and ("call" in item_type or "tool" in item_type):
             # Parse other tool calls
             parsed = _parse_tool_call(item)
             if parsed.get("tool_calls"):
@@ -314,8 +306,9 @@ def _parse_output_array(output_array) -> Dict[str, Any]:
             if parsed.get("code_outputs"):
                 all_code_outputs.extend(parsed["code_outputs"])
 
-
-    result["text"] = text if text else None # TODO: they can potentially send multiple complete text messages, we might need to save all of them and only return the first that can convert to outpu parser
+    result["text"] = (
+        text if text else None
+    )  # TODO: they can potentially send multiple complete text messages, we might need to save all of them and only return the first that can convert to outpu parser
 
     # Set other fields if they have content
     result["images"] = all_images
@@ -333,7 +326,7 @@ def _serialize_item(item) -> Dict[str, Any]:
     """Convert an output item to a serializable dict."""
     result = {}
     for attr in dir(item):
-        if not attr.startswith('_'):
+        if not attr.startswith("_"):
             value = getattr(item, attr, None)
             if value is not None and not callable(value):
                 result[attr] = value
@@ -404,8 +397,6 @@ def handle_streaming_response_sync(stream: Iterable) -> GeneratorType:
     # already compatible as this is the OpenAI client
     for event in stream:
         yield event
-
-
 
 
 class OpenAIClient(ModelClient):
@@ -800,7 +791,6 @@ class OpenAIClient(ModelClient):
             if parsed_content.reasoning:
                 thinking = str(parsed_content.reasoning)
 
-
             return GeneratorOutput(
                 data=data,  # only text
                 thinking=thinking,
@@ -808,13 +798,12 @@ class OpenAIClient(ModelClient):
                 tool_use=None,  # Will be populated when we handle function tool calls
                 error=None,
                 raw_response=data,
-                usage=usage
+                usage=usage,
             )
         # Regular response handling (streaming or other)
         data = parser(completion)
         usage = self.track_completion_usage(completion)
         return GeneratorOutput(data=None, error=None, raw_response=data, usage=usage)
-
 
     # NEW RESPONSE API ONLY FUNCTION
     def track_completion_usage(
@@ -968,12 +957,7 @@ class OpenAIClient(ModelClient):
                 content = format_content_for_response_api(input, images)
 
                 # For responses.create API, wrap in user message format
-                final_model_kwargs["input"] = [
-                    {
-                        "role": "user",
-                        "content": content
-                    }
-                ]
+                final_model_kwargs["input"] = [{"role": "user", "content": content}]
             else:
                 # Text-only input
                 final_model_kwargs["input"] = input

--- a/adalflow/tests/test_openai_client.py
+++ b/adalflow/tests/test_openai_client.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, AsyncMock, Mock, MagicMock
+from unittest.mock import patch, AsyncMock, Mock
 import os
 import base64
 
@@ -176,8 +176,11 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
                 "role": "user",
                 "content": [
                     {"type": "input_text", "text": "Describe this image"},
-                    {"type": "input_image", "image_url": "https://example.com/image.jpg"}
-                ]
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/image.jpg",
+                    },
+                ],
             }
         ]
         self.assertEqual(result["input"], expected_input)
@@ -203,9 +206,15 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
                 "role": "user",
                 "content": [
                     {"type": "input_text", "text": "Compare these images"},
-                    {"type": "input_image", "image_url": "https://example.com/image1.jpg"},
-                    {"type": "input_image", "image_url": "https://example.com/image2.jpg"}
-                ]
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/image1.jpg",
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/image2.jpg",
+                    },
+                ],
             }
         ]
         self.assertEqual(result["input"], expected_input)
@@ -522,22 +531,25 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
         mock_reasoning_response.created_at = 1635820005.0
         mock_reasoning_response.model = "o1"
         mock_reasoning_response.object = "response"
-        mock_reasoning_response.output_text = None  # Reasoning models may not have output_text
-        
+        mock_reasoning_response.output_text = (
+            None  # Reasoning models may not have output_text
+        )
+
         # Mock output array with reasoning and message
         mock_reasoning_item = Mock()
         mock_reasoning_item.type = "reasoning"
         mock_reasoning_item.id = "rs_123"
         mock_reasoning_item.summary = [
-            Mock(type="summary_text", text="I'm thinking about the problem step by step...")
+            Mock(
+                type="summary_text",
+                text="I'm thinking about the problem step by step...",
+            )
         ]
-        
+
         mock_message_item = Mock()
         mock_message_item.type = "message"
-        mock_message_item.content = [
-            Mock(type="output_text", text="The answer is 42.")
-        ]
-        
+        mock_message_item.content = [Mock(type="output_text", text="The answer is 42.")]
+
         mock_reasoning_response.output = [mock_reasoning_item, mock_message_item]
         mock_reasoning_response.usage = ResponseUsage(
             input_tokens=50,
@@ -546,10 +558,10 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
             input_tokens_details={"cached_tokens": 0},
             output_tokens_details={"reasoning_tokens": 80},
         )
-        
+
         # Parse the response
         result = self.client.parse_chat_completion(mock_reasoning_response)
-        
+
         # Assertions
         self.assertIsInstance(result, GeneratorOutput)
         self.assertEqual(result.data, "The answer is 42.")
@@ -564,41 +576,38 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
         # Test with URL image
         url_kwargs = self.client.convert_inputs_to_api_kwargs(
             input="What's in this image?",
-            model_kwargs={
-                "model": "gpt-4o",
-                "images": "https://example.com/image.jpg"
-            },
-            model_type=ModelType.LLM
+            model_kwargs={"model": "gpt-4o", "images": "https://example.com/image.jpg"},
+            model_type=ModelType.LLM,
         )
-        
+
         # Should format as message with content array
         self.assertIn("input", url_kwargs)
         self.assertIsInstance(url_kwargs["input"], list)
         self.assertEqual(url_kwargs["input"][0]["role"], "user")
         content = url_kwargs["input"][0]["content"]
         self.assertIsInstance(content, list)
-        
+
         # Check text content
         text_content = next((c for c in content if c["type"] == "input_text"), None)
         self.assertIsNotNone(text_content)
         self.assertEqual(text_content["text"], "What's in this image?")
-        
+
         # Check image content
         image_content = next((c for c in content if c["type"] == "input_image"), None)
         self.assertIsNotNone(image_content)
         self.assertEqual(image_content["image_url"], "https://example.com/image.jpg")
-        
+
         # Test with base64 image
         base64_image = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
         base64_kwargs = self.client.convert_inputs_to_api_kwargs(
             input="Describe this image",
             model_kwargs={
                 "model": "gpt-4o",
-                "images": f"data:image/png;base64,{base64_image}"
+                "images": f"data:image/png;base64,{base64_image}",
             },
-            model_type=ModelType.LLM
+            model_type=ModelType.LLM,
         )
-        
+
         # Check base64 image content
         content = base64_kwargs["input"][0]["content"]
         image_content = next((c for c in content if c["type"] == "input_image"), None)
@@ -614,18 +623,18 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
         mock_image_response.model = "gpt-4o"
         mock_image_response.object = "response"
         mock_image_response.output_text = None
-        
+
         # Mock output array with image generation call
         mock_image_item = Mock()
         mock_image_item.type = "image_generation_call"
         mock_image_item.result = "base64_encoded_image_data_here"
-        
+
         mock_message_item = Mock()
         mock_message_item.type = "message"
         mock_message_item.content = [
             Mock(type="output_text", text="I've generated an image of a cat for you.")
         ]
-        
+
         mock_image_response.output = [mock_image_item, mock_message_item]
         mock_image_response.usage = ResponseUsage(
             input_tokens=30,
@@ -634,43 +643,42 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
             input_tokens_details={"cached_tokens": 0},
             output_tokens_details={"reasoning_tokens": 0},
         )
-        
+
         # Parse the response
         result = self.client.parse_chat_completion(mock_image_response)
-        
+
         # Assertions
         self.assertIsInstance(result, GeneratorOutput)
         self.assertEqual(result.data, "I've generated an image of a cat for you.")
         self.assertIsNotNone(result.images)
         self.assertEqual(result.images, ["base64_encoded_image_data_here"])
 
-
     def test_streaming_with_helper_function(self):
         """Test streaming response with text extraction helper."""
         # Create streaming events with proper structure
         event1 = Mock()
         event1.type = "response.created"
-        
+
         event2 = Mock()
         event2.type = "response.output_text.delta"
         event2.delta = "Hello "
-        
+
         event3 = Mock()
         event3.type = "response.output_text.delta"
         event3.delta = "world!"
-        
+
         event4 = Mock()
         event4.type = "response.done"
-        
+
         events = [event1, event2, event3, event4]
-        
+
         # Test text extraction
         extracted_text = []
         for event in events:
             text = extract_text_from_response_stream(event)
             if text:
                 extracted_text.append(text)
-        
+
         # Assertions
         self.assertEqual(extracted_text, ["Hello ", "world!"])
         self.assertEqual("".join(extracted_text), "Hello world!")
@@ -679,54 +687,54 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
         """Test streaming with reasoning model responses."""
         # Setup mock
         mock_async_client = AsyncMock()
-        
+
         # Create reasoning streaming events with proper structure
         async def mock_reasoning_stream():
             # Reasoning events
             event1 = Mock()
             event1.type = "reasoning.start"
             yield event1
-            
+
             event2 = Mock()
             event2.type = "reasoning.delta"
             event2.delta = "Thinking..."
             yield event2
-            
+
             # Text output events
             event3 = Mock()
             event3.type = "response.output_text.delta"
             event3.delta = "The answer "
             yield event3
-            
+
             event4 = Mock()
             event4.type = "response.output_text.delta"
             event4.delta = "is 42."
             yield event4
-            
+
             event5 = Mock()
             event5.type = "response.done"
             yield event5
-        
+
         mock_async_client.responses.create.return_value = mock_reasoning_stream()
         self.client.async_client = mock_async_client
-        
+
         # Call with reasoning model
         api_kwargs = {
             "model": "o1",
             "input": "What is the meaning of life?",
             "stream": True,
-            "reasoning": {"effort": "medium", "summary": "auto"}
+            "reasoning": {"effort": "medium", "summary": "auto"},
         }
-        
+
         stream = await self.client.acall(api_kwargs, ModelType.LLM_REASONING)
-        
+
         # Process the stream
         text_chunks = []
         async for event in stream:
             text = extract_text_from_response_stream(event)
             if text:
                 text_chunks.append(text)
-        
+
         # Assertions
         self.assertEqual("".join(text_chunks), "The answer is 42.")
 
@@ -740,27 +748,32 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
                 "images": [
                     "https://example.com/image1.jpg",
                     "https://example.com/image2.jpg",
-                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
-                ]
+                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+                ],
             },
-            model_type=ModelType.LLM
+            model_type=ModelType.LLM,
         )
-        
+
         # Check content array
         content = multi_image_kwargs["input"][0]["content"]
-        
+
         # Should have 1 text + 3 images = 4 items
         self.assertEqual(len(content), 4)
-        
+
         # Count image contents
         image_contents = [c for c in content if c["type"] == "input_image"]
         self.assertEqual(len(image_contents), 3)
-        
-        # Verify each image
-        self.assertEqual(image_contents[0]["image_url"], "https://example.com/image1.jpg")
-        self.assertEqual(image_contents[1]["image_url"], "https://example.com/image2.jpg")
-        self.assertTrue(image_contents[2]["image_url"].startswith("data:image/png;base64,"))
 
+        # Verify each image
+        self.assertEqual(
+            image_contents[0]["image_url"], "https://example.com/image1.jpg"
+        )
+        self.assertEqual(
+            image_contents[1]["image_url"], "https://example.com/image2.jpg"
+        )
+        self.assertTrue(
+            image_contents[2]["image_url"].startswith("data:image/png;base64,")
+        )
 
     def test_strip_unsupported_reasoning_kwargs_removes_frequency_penalty(self):
         """frequency_penalty is stripped for reasoning model prefixes."""

--- a/adalflow/tests/test_openai_client.py
+++ b/adalflow/tests/test_openai_client.py
@@ -762,5 +762,45 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(image_contents[2]["image_url"].startswith("data:image/png;base64,"))
 
 
+    def test_strip_unsupported_reasoning_kwargs_removes_frequency_penalty(self):
+        """frequency_penalty is stripped for reasoning model prefixes."""
+        for model in ("o1", "o3-mini", "o4-turbo", "gpt-5"):
+            with self.subTest(model=model):
+                kwargs = {"model": model, "input": "hi", "frequency_penalty": 0.5}
+                result = self.client._strip_unsupported_reasoning_kwargs(kwargs)
+                self.assertNotIn("frequency_penalty", result)
+                self.assertEqual(result["model"], model)
+                self.assertEqual(result["input"], "hi")
+
+    def test_strip_unsupported_reasoning_kwargs_preserves_non_reasoning_models(self):
+        """frequency_penalty is NOT stripped for non-reasoning models."""
+        kwargs = {"model": "gpt-4o", "input": "hi", "frequency_penalty": 0.5}
+        result = self.client._strip_unsupported_reasoning_kwargs(kwargs)
+        self.assertIn("frequency_penalty", result)
+        self.assertEqual(result["frequency_penalty"], 0.5)
+
+    def test_strip_unsupported_reasoning_kwargs_leaves_other_kwargs_intact(self):
+        """Other kwargs like temperature and max_tokens are never removed."""
+        kwargs = {
+            "model": "o3-mini",
+            "input": "hi",
+            "temperature": 0.7,
+            "max_tokens": 100,
+            "frequency_penalty": 0.5,
+        }
+        result = self.client._strip_unsupported_reasoning_kwargs(kwargs)
+        self.assertIn("temperature", result)
+        self.assertIn("max_tokens", result)
+        self.assertNotIn("frequency_penalty", result)
+
+    def test_strip_unsupported_reasoning_kwargs_does_not_mutate_input(self):
+        """The helper must return a new dict and leave the original untouched."""
+        kwargs = {"model": "o1", "input": "hi", "frequency_penalty": 0.5}
+        original = kwargs.copy()
+        result = self.client._strip_unsupported_reasoning_kwargs(kwargs)
+        self.assertEqual(kwargs, original)
+        self.assertIsNot(result, kwargs)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes #481

### Problem
When AdalFlow is used with OpenAI reasoning models (o1, o3, o3-mini, o4, gpt-5 family), every API call fails with:

`Responses.create() got an unexpected keyword argument 'frequency_penalty'`

This breaks the official quickstart Colab notebook and any user code that passes `frequency_penalty` (a common default) when using a reasoning model. OpenAI's Responses API rejects `frequency_penalty` for reasoning models, but AdalFlow forwards all kwargs unconditionally.

### Fix
Adds a `_strip_unsupported_reasoning_kwargs` helper on `OpenAIClient` that:
- Detects reasoning models by model-name prefix (`o1`, `o3`, `o4`, `gpt-5`).
- Removes a configurable allowlist of unsupported kwargs (`_UNSUPPORTED_REASONING_KWARGS`).
- Returns a copy — never mutates the caller's dict.
- Logs stripped kwargs at debug level.

The helper is invoked at the top of the LLM/LLM_REASONING branch in both `call` and `acall`, so both sync and async paths are covered.

### Scope
Conservative on purpose: only `frequency_penalty` is stripped right now, since that is the parameter confirmed broken in #481. The constant `_UNSUPPORTED_REASONING_KWARGS` is a tuple so additional params (`presence_penalty`, `top_p`, `logit_bias`, etc.) can be added in follow-up PRs as they are independently confirmed.

### Tests
Added four unit tests in `adalflow/tests/test_openai_client.py`:
1. `frequency_penalty` is stripped for each reasoning prefix (`o1`, `o3-mini`, `o4-turbo`, `gpt-5`).
2. `frequency_penalty` is preserved for non-reasoning models (e.g. `gpt-4o`).
3. Unrelated kwargs (`temperature`, `max_tokens`) are left intact.
4. The helper does not mutate the input dict.

### Before submitting
- [x] Did you read the contributor guideline?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you write any new necessary tests?
- [x] Did you verify new and existing tests pass locally with your changes?