### PR TITLE
fix(types): normalise Function.args/kwargs None to [] / {} in __post_init__

### DIFF
--- a/adalflow/adalflow/core/types.py
+++ b/adalflow/adalflow/core/types.py
@@ -402,6 +402,15 @@ class Function(DataClass):
         metadata={"desc": "The final answer if this is the final output."},
     )
 
+    def __post_init__(self):
+        super().__post_init__()
+        # LLM parsers may deserialize omitted or null fields as None.
+        # Normalise to empty containers so *args/**kwargs unpacking never fails.
+        if self.args is None:
+            self.args = []
+        if self.kwargs is None:
+            self.kwargs = {}
+
     @classmethod
     def from_function(
         cls,

--- a/adalflow/tests/test_tool.py
+++ b/adalflow/tests/test_tool.py
@@ -907,3 +907,52 @@ def test_tool_manager_with_grad_component():
     # ensure it is the forward method that is called
     output = test_com.tools_manager.tools[1](1, 2)
     assert output.data.output == -1
+
+
+# ---- Function None-args/kwargs normalisation (issue #479) ----
+
+
+def test_function_none_args_normalised_to_empty_list():
+    """Function(args=None) must not store None; __post_init__ normalises it to []."""
+    func = Function(name="my_tool", args=None, kwargs={"city": "Budapest"})
+    assert func.args == [], "args=None should be normalised to []"
+    assert func.kwargs == {"city": "Budapest"}
+
+
+def test_function_none_kwargs_normalised_to_empty_dict():
+    """Function(kwargs=None) must not store None; __post_init__ normalises it to {}."""
+    func = Function(name="my_tool", args=[1, 2], kwargs=None)
+    assert func.args == [1, 2]
+    assert func.kwargs == {}, "kwargs=None should be normalised to {}"
+
+
+def test_function_both_none_normalised():
+    """Function(args=None, kwargs=None) normalises both fields."""
+    func = Function(name="my_tool", args=None, kwargs=None)
+    assert func.args == []
+    assert func.kwargs == {}
+
+
+def test_function_tool_call_with_none_args_does_not_raise():
+    """tool.call(*func.args, **func.kwargs) must not raise when the LLM omits args."""
+
+    def weather(city: str) -> str:
+        return f"Weather in {city}"
+
+    tool = FunctionTool(fn=weather)
+    func = Function(name="weather", args=None, kwargs={"city": "Budapest"})
+
+    output = tool.call(*func.args, **func.kwargs)
+    assert output.output == "Weather in Budapest"
+
+
+def test_tool_manager_execute_func_with_none_args():
+    """ToolManager.execute_func must succeed when func.args is None."""
+
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    manager = ToolManager(tools=[FunctionTool(fn=greet)])
+    func = Function(name="greet", args=None, kwargs={"name": "Alice"})
+    result = manager.execute_func(func)
+    assert result.output == "Hello, Alice!"


### PR DESCRIPTION
## Summary

Fixes #479.

`Function` declares `args` and `kwargs` as `Optional[List]` / `Optional[Dict]` with `default_factory=list` / `default_factory=dict`. The defaults only apply when a field is **omitted**; an explicit `None` (which `JsonOutputParser` produces when the LLM omits or nullifies a field) bypasses the factory and stores `None` directly. Any subsequent unpack (`*func.args`, `**func.kwargs`) then raises:

```
TypeError: argument after * must be an iterable, not NoneType
```

This crash affects every call site that unpacks `func.args`/`func.kwargs` — `ToolManager.execute_func`, `ToolManager.execute_func_async`, `CallFunctionTool.call`, and `PermissionManager`.

## Fix

Add `Function.__post_init__` (calling `super().__post_init__()` to keep base-class metadata validation) that normalises `None → []` for `args` and `None → {}` for `kwargs`. All existing and future call sites are protected without per-site guard code.

```python
def __post_init__(self):
    super().__post_init__()
    if self.args is None:
        self.args = []
    if self.kwargs is None:
        self.kwargs = {}
```

## Tests

Five new tests added to `adalflow/tests/test_tool.py`:

| Test | What it checks |
|---|---|
| `test_function_none_args_normalised_to_empty_list` | `Function(args=None)` stores `[]` |
| `test_function_none_kwargs_normalised_to_empty_dict` | `Function(kwargs=None)` stores `{}` |
| `test_function_both_none_normalised` | Both `None` at once |
| `test_function_tool_call_with_none_args_does_not_raise` | `tool.call(*func.args, **func.kwargs)` doesn't crash |
| `test_tool_manager_execute_func_with_none_args` | `ToolManager.execute_func` round-trip |

All 29 tests in `test_tool.py` pass (24 pre-existing + 5 new).