### PR TITLE
feat(benchmarks): add OpenEvolve-style research loop smoke benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,3 +1,66 @@
+# Benchmarks
+
 Benchmarking is an integral development part of the project.
 
-Contributors are encouraged to write benchmarks for their code, besides of the unit tests in `tests/` directory.
+Contributors are encouraged to write benchmarks for their code, in addition to unit tests in the `tests/` directory.
+
+## Available benchmark areas
+
+- `optimize_anything/` — GEPA / optimize-anything style benchmark scaffolds.
+- `arc_bench/` — ARC-Bench-style smoke benchmark harness for autonomous research-agent prototypes.
+
+## ARC-Bench-style smoke benchmark
+
+The `arc_bench/` benchmark is a lightweight, local smoke benchmark for testing AdalFlow research-agent orchestration patterns. It currently supports:
+
+1. A simple linear autonomous-research demo.
+2. An OpenEvolve-style evolutionary research loop demo.
+
+The evolutionary loop models:
+
+```text
+seed candidate
+→ mutate
+→ execute / repair
+→ evaluate
+→ reflect
+→ archive
+→ select best
+→ repeat
+→ final report
+```
+
+Run the deterministic evolution smoke benchmark:
+
+```bash
+python benchmarks/arc_bench/run_adalflow_smoke.py \
+  --mode evolution \
+  --max-iterations 5 \
+  --topics benchmarks/arc_bench/topics_smoke.jsonl \
+  --output artifacts/arc_bench/adalflow_evolution_smoke
+```
+
+Generate a Markdown report:
+
+```bash
+python benchmarks/arc_bench/report.py \
+  --input artifacts/arc_bench/adalflow_evolution_smoke \
+  --output artifacts/arc_bench/adalflow_evolution_smoke_report.md
+```
+
+Optional LLM-backed mode replaces the seed, mutation, reflection, and final report-writing components with AdalFlow `Generator` components while keeping execution and evaluation deterministic:
+
+```bash
+export OPENAI_API_KEY="..."
+
+python benchmarks/arc_bench/run_adalflow_smoke.py \
+  --mode evolution \
+  --use-llm \
+  --provider openai \
+  --model gpt-4o-mini \
+  --max-iterations 5 \
+  --topics benchmarks/arc_bench/topics_smoke.jsonl \
+  --output artifacts/arc_bench/adalflow_evolution_llm_smoke
+```
+
+> Note: this benchmark is not a verified comparison against AutoResearchClaw. A valid comparison requires running both systems on the same topics, model, hardware, timeout, budget, and scoring rubric.

--- a/benchmarks/arc_bench/README.md
+++ b/benchmarks/arc_bench/README.md
@@ -1,0 +1,137 @@
+# ARC-Bench-style Smoke Benchmark
+
+This directory contains a lightweight ARC-Bench-style smoke benchmark for AdalFlow autonomous research-agent prototypes.
+
+It is designed to validate **agent control-flow shape** rather than claim external benchmark superiority. The current benchmark is local, deterministic by default, and safe to run without API keys.
+
+## Files
+
+- `topics_smoke.jsonl` — 5 ARC-Bench-style smoke topics:
+  - 2 machine learning topics
+  - 1 statistics topic
+  - 1 biology topic
+  - 1 quantum topic
+- `run_adalflow_smoke.py` — benchmark runner for AdalFlow research demos.
+- `metrics.py` — normalized per-topic metrics.
+- `report.py` — Markdown report generator.
+
+## Supported modes
+
+### 1. Simple mode
+
+Runs the original linear autonomous-research prototype:
+
+```text
+topic → literature → hypothesis → HITL gate → code repair → report status
+```
+
+Command:
+
+```bash
+python benchmarks/arc_bench/run_adalflow_smoke.py \
+  --mode simple \
+  --topics benchmarks/arc_bench/topics_smoke.jsonl \
+  --output artifacts/arc_bench/adalflow_simple_smoke
+```
+
+### 2. Evolution mode
+
+Runs the OpenEvolve-style research loop:
+
+```text
+seed candidate
+→ mutate
+→ execute / repair
+→ evaluate
+→ reflect
+→ archive
+→ select best
+→ repeat
+→ final report
+```
+
+Command:
+
+```bash
+python benchmarks/arc_bench/run_adalflow_smoke.py \
+  --mode evolution \
+  --max-iterations 5 \
+  --topics benchmarks/arc_bench/topics_smoke.jsonl \
+  --output artifacts/arc_bench/adalflow_evolution_smoke
+```
+
+Generate a report:
+
+```bash
+python benchmarks/arc_bench/report.py \
+  --input artifacts/arc_bench/adalflow_evolution_smoke \
+  --output artifacts/arc_bench/adalflow_evolution_smoke_report.md
+```
+
+## Optional LLM-backed mode
+
+Evolution mode can optionally replace the seed, mutation, reflection, and final report-writing steps with AdalFlow `Generator` components:
+
+```bash
+export OPENAI_API_KEY="..."
+
+python benchmarks/arc_bench/run_adalflow_smoke.py \
+  --mode evolution \
+  --use-llm \
+  --provider openai \
+  --model gpt-4o-mini \
+  --max-iterations 5 \
+  --topics benchmarks/arc_bench/topics_smoke.jsonl \
+  --output artifacts/arc_bench/adalflow_evolution_llm_smoke
+```
+
+Supported providers:
+
+- `openai`
+- `groq`
+- `anthropic`
+
+The executor and evaluator remain deterministic in this phase so that smoke benchmark metrics stay reproducible and safe.
+
+## Metrics
+
+The benchmark records one `metrics.json` per topic and one aggregate `summary.json`.
+
+For evolution mode, key metrics include:
+
+- `initial_score`
+- `best_score`
+- `score_improvement`
+- `num_candidates`
+- `retry_count`
+- `convergence_iteration`
+- `archive_size`
+- `artifact_completeness`
+
+Example output structure:
+
+```text
+artifacts/arc_bench/
+├── adalflow_evolution_smoke/
+│   ├── ml_001/
+│   │   ├── metrics.json
+│   │   └── result.json
+│   ├── ...
+│   └── summary.json
+└── adalflow_evolution_smoke_report.md
+```
+
+## Important limitation
+
+This is not a verified AdalFlow-vs-AutoResearchClaw benchmark.
+
+A fair external comparison requires:
+
+1. The same topic set.
+2. The same LLM model and decoding configuration.
+3. The same hardware and sandbox policy.
+4. The same timeout and cost budget.
+5. The same scoring rubric.
+6. Raw artifacts for both systems.
+
+The next step is to add an AutoResearchClaw runner that executes the same `topics_smoke.jsonl` file and emits the same normalized `metrics.json` schema.

--- a/benchmarks/arc_bench/__init__.py
+++ b/benchmarks/arc_bench/__init__.py
@@ -1,0 +1,1 @@
+"""ARC-Bench smoke benchmark utilities for autonomous research agents."""

--- a/benchmarks/arc_bench/metrics.py
+++ b/benchmarks/arc_bench/metrics.py
@@ -1,0 +1,124 @@
+"""Shared metrics for ARC-Bench smoke benchmark runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class SmokeMetrics:
+    """Normalized per-topic benchmark metrics.
+
+    These metrics intentionally measure only the local smoke benchmark behavior.
+    They are not comparable to AutoResearchClaw's published ARC-Bench results
+    until both systems are run under the same environment and scoring rubric.
+    """
+
+    system: str
+    topic_id: str
+    domain: str
+    topic: str
+    completed: bool
+    stages_total: int
+    stages_completed: int
+    stage_completion_rate: float
+    retry_count: int
+    wall_time_sec: float
+    experiment_success: bool
+    paper_generated: bool
+    artifact_completeness: float
+    best_score: Optional[float] = None
+    initial_score: Optional[float] = None
+    score_improvement: Optional[float] = None
+    num_candidates: Optional[int] = None
+    convergence_iteration: Optional[int] = None
+    archive_size: Optional[int] = None
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def build_smoke_metrics(
+    *,
+    system: str,
+    topic_record: Dict[str, str],
+    result: Optional[Dict[str, Any]],
+    wall_time_sec: float,
+    error: Optional[str] = None,
+) -> SmokeMetrics:
+    """Convert a pipeline result into normalized smoke benchmark metrics."""
+
+    completed = error is None and bool(result)
+    experiment_metrics = result.get("experiment_metrics", {}) if result else {}
+    output_status = result.get("output_status", "") if result else ""
+
+    experiment_success = bool(experiment_metrics)
+    paper_generated = output_status.startswith("Successfully")
+
+    is_evolution_loop = "best_score" in experiment_metrics
+    if is_evolution_loop:
+        stages_total = 6
+        stages_completed = sum(
+            [
+                completed,
+                bool(result and result.get("hypothesis")),
+                bool(result and result.get("evolution_history")),
+                experiment_success,
+                bool(experiment_metrics.get("num_candidates", 0)),
+                paper_generated,
+            ]
+        )
+        retry_count = int(experiment_metrics.get("retry_count", 0))
+        artifacts = [
+            bool(result and result.get("hypothesis")),
+            bool(result and result.get("best_candidate")),
+            bool(result and result.get("evolution_history")),
+            experiment_success,
+            paper_generated,
+        ]
+    else:
+        # The simple demo models four coarse stage groups:
+        # literature, hypothesis/HITL, code execution/repair, paper status.
+        stages_total = 4
+        stages_completed = sum(
+            [
+                completed,
+                bool(result and result.get("hypothesis")),
+                experiment_success,
+                paper_generated,
+            ]
+        )
+        # The simple demo intentionally triggers one failed sandbox attempt and repairs it.
+        retry_count = 1 if experiment_success else 0
+        artifacts = [
+            bool(result and result.get("hypothesis")),
+            experiment_success,
+            paper_generated,
+        ]
+
+    artifact_completeness = sum(artifacts) / len(artifacts)
+
+    return SmokeMetrics(
+        system=system,
+        topic_id=topic_record["topic_id"],
+        domain=topic_record["domain"],
+        topic=topic_record["topic"],
+        completed=completed and stages_completed == stages_total,
+        stages_total=stages_total,
+        stages_completed=stages_completed,
+        stage_completion_rate=stages_completed / stages_total,
+        retry_count=retry_count,
+        wall_time_sec=wall_time_sec,
+        experiment_success=experiment_success,
+        paper_generated=paper_generated,
+        artifact_completeness=artifact_completeness,
+        best_score=experiment_metrics.get("best_score"),
+        initial_score=experiment_metrics.get("initial_score"),
+        score_improvement=experiment_metrics.get("score_improvement"),
+        num_candidates=experiment_metrics.get("num_candidates"),
+        convergence_iteration=experiment_metrics.get("convergence_iteration"),
+        archive_size=experiment_metrics.get("archive_size"),
+        error=error,
+    )

--- a/benchmarks/arc_bench/report.py
+++ b/benchmarks/arc_bench/report.py
@@ -1,0 +1,129 @@
+"""Generate a Markdown report for ARC-Bench smoke benchmark outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+def load_json(path: Path) -> Dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def collect_metrics(input_dir: Path) -> List[Dict]:
+    return [load_json(path) for path in sorted(input_dir.glob("*/metrics.json"))]
+
+
+def _format_optional(value, fmt: str = ".4f") -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (int, float)):
+        return f"{value:{fmt}}"
+    return str(value)
+
+
+def render_report(input_dir: Path) -> str:
+    summary = load_json(input_dir / "summary.json")
+    rows = collect_metrics(input_dir)
+    has_evolution_metrics = any(row.get("best_score") is not None for row in rows)
+
+    lines = [
+        "# AdalFlow ARC-Bench Smoke Benchmark Report",
+        "",
+        "> This is a 5-topic smoke benchmark for the AdalFlow autonomous research demo only. "
+        "It is not a verified comparison against AutoResearchClaw until both systems are run "
+        "under the same model, hardware, timeout, budget, and scoring rubric.",
+        "",
+        "## Summary",
+        "",
+        f"- System: `{summary.get('system', 'unknown')}`",
+        f"- Mode: `{summary.get('mode', 'unknown')}`",
+        f"- Topics: {summary.get('topics', 0)}",
+        f"- Completed: {summary.get('completed', 0)}",
+        f"- Completion rate: {summary.get('completion_rate', 0):.2%}",
+        f"- Mean stage completion rate: {summary.get('mean_stage_completion_rate', 0):.2%}",
+        f"- Mean retry count: {summary.get('mean_retry_count', 0):.2f}",
+        f"- Mean wall time: {summary.get('mean_wall_time_sec', 0):.4f}s",
+        f"- Experiment success rate: {summary.get('experiment_success_rate', 0):.2%}",
+        f"- Paper generated rate: {summary.get('paper_generated_rate', 0):.2%}",
+        f"- Mean artifact completeness: {summary.get('mean_artifact_completeness', 0):.2%}",
+    ]
+
+    if has_evolution_metrics:
+        lines.extend(
+            [
+                f"- Mean initial score: {summary.get('mean_initial_score', 0):.4f}",
+                f"- Mean best score: {summary.get('mean_best_score', 0):.4f}",
+                f"- Mean score improvement: {summary.get('mean_score_improvement', 0):.4f}",
+                f"- Mean candidates explored: {summary.get('mean_num_candidates', 0):.2f}",
+                f"- Mean convergence iteration: {summary.get('mean_convergence_iteration', 0):.2f}",
+                f"- Mean archive size: {summary.get('mean_archive_size', 0):.2f}",
+            ]
+        )
+
+    lines.extend(["", "## Per-topic Results", ""])
+
+    if has_evolution_metrics:
+        lines.extend(
+            [
+                "| Topic ID | Domain | Completed | Best Score | Improvement | Candidates | Retries | Converged At | Wall Time (s) |",
+                "|---|---|---:|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in rows:
+            lines.append(
+                "| {topic_id} | {domain} | {completed} | {best_score} | {improvement} | "
+                "{candidates} | {retry_count} | {converged} | {wall_time_sec:.4f} |".format(
+                    topic_id=row["topic_id"],
+                    domain=row["domain"],
+                    completed=row["completed"],
+                    best_score=_format_optional(row.get("best_score")),
+                    improvement=_format_optional(row.get("score_improvement")),
+                    candidates=_format_optional(row.get("num_candidates"), ".0f"),
+                    retry_count=row["retry_count"],
+                    converged=_format_optional(row.get("convergence_iteration"), ".0f"),
+                    wall_time_sec=row["wall_time_sec"],
+                )
+            )
+    else:
+        lines.extend(
+            [
+                "| Topic ID | Domain | Completed | Stage Completion | Retries | Wall Time (s) | Experiment | Paper |",
+                "|---|---|---:|---:|---:|---:|---:|---:|",
+            ]
+        )
+        for row in rows:
+            lines.append(
+                "| {topic_id} | {domain} | {completed} | {stage_completion_rate:.2%} | "
+                "{retry_count} | {wall_time_sec:.4f} | {experiment_success} | {paper_generated} |".format(**row)
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Next Step",
+            "",
+            "Add a second runner for AutoResearchClaw and execute both systems over the same topic file "
+            "to produce a real baseline-vs-candidate comparison.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=Path("artifacts/arc_bench/adalflow_evolution_smoke"))
+    parser.add_argument("--output", type=Path, default=Path("artifacts/arc_bench/adalflow_evolution_smoke_report.md"))
+    args = parser.parse_args()
+
+    report = render_report(args.input)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report, encoding="utf-8")
+    print(f"Wrote report to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/arc_bench/run_adalflow_smoke.py
+++ b/benchmarks/arc_bench/run_adalflow_smoke.py
@@ -1,0 +1,179 @@
+"""Run a 5-topic ARC-Bench-style smoke benchmark for AdalFlow research demos."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from benchmarks.arc_bench.metrics import build_smoke_metrics
+from use_cases.multi_agent_dag.auto_research_claw_demo import AutoResearchPipeline
+from use_cases.multi_agent_dag.open_evolve_research_demo import OpenEvolveResearchLoop
+
+
+PipelineMode = Literal["simple", "evolution"]
+
+
+def load_topics(path: Path) -> List[Dict[str, str]]:
+    topics: List[Dict[str, str]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            topics.append(json.loads(line))
+    return topics
+
+
+def write_json(path: Path, payload: Dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_pipeline(
+    mode: PipelineMode,
+    max_iterations: int,
+    *,
+    use_llm: bool,
+    provider: str,
+    model_kwargs: Dict,
+):
+    if mode == "simple":
+        return "adalflow-auto-research-demo", AutoResearchPipeline(hitl_mode="auto")
+    if mode == "evolution":
+        system = (
+            "adalflow-open-evolve-research-demo-llm"
+            if use_llm
+            else "adalflow-open-evolve-research-demo"
+        )
+        return system, OpenEvolveResearchLoop(
+            max_iterations=max_iterations,
+            use_llm=use_llm,
+            provider=provider,
+            model_kwargs=model_kwargs,
+        )
+    raise ValueError(f"Unsupported mode: {mode}")
+
+
+def summarize(metrics: Iterable[Dict], *, system: str, mode: PipelineMode, use_llm: bool) -> Dict:
+    rows = list(metrics)
+    count = len(rows)
+    if count == 0:
+        return {"system": system, "mode": mode, "use_llm": use_llm, "topics": 0}
+
+    summary = {
+        "system": system,
+        "mode": mode,
+        "use_llm": use_llm,
+        "topics": count,
+        "completed": sum(1 for row in rows if row["completed"]),
+        "completion_rate": sum(1 for row in rows if row["completed"]) / count,
+        "mean_stage_completion_rate": sum(row["stage_completion_rate"] for row in rows) / count,
+        "mean_retry_count": sum(row["retry_count"] for row in rows) / count,
+        "mean_wall_time_sec": sum(row["wall_time_sec"] for row in rows) / count,
+        "experiment_success_rate": sum(1 for row in rows if row["experiment_success"]) / count,
+        "paper_generated_rate": sum(1 for row in rows if row["paper_generated"]) / count,
+        "mean_artifact_completeness": sum(row["artifact_completeness"] for row in rows) / count,
+    }
+
+    if any(row.get("best_score") is not None for row in rows):
+        summary.update(
+            {
+                "mean_best_score": sum(row.get("best_score") or 0 for row in rows) / count,
+                "mean_initial_score": sum(row.get("initial_score") or 0 for row in rows) / count,
+                "mean_score_improvement": sum(row.get("score_improvement") or 0 for row in rows) / count,
+                "mean_num_candidates": sum(row.get("num_candidates") or 0 for row in rows) / count,
+                "mean_convergence_iteration": sum(
+                    row.get("convergence_iteration") or 0 for row in rows
+                )
+                / count,
+                "mean_archive_size": sum(row.get("archive_size") or 0 for row in rows) / count,
+            }
+        )
+
+    return summary
+
+
+def run(
+    topics_path: Path,
+    output_dir: Path,
+    *,
+    mode: PipelineMode = "evolution",
+    max_iterations: int = 5,
+    use_llm: bool = False,
+    provider: str = "openai",
+    model_kwargs: Dict | None = None,
+) -> Dict:
+    topics = load_topics(topics_path)
+    model_kwargs = model_kwargs or {"model": "gpt-4o-mini", "temperature": 0.3}
+    system, pipeline = build_pipeline(
+        mode,
+        max_iterations,
+        use_llm=use_llm,
+        provider=provider,
+        model_kwargs=model_kwargs,
+    )
+    all_metrics: List[Dict] = []
+
+    for topic_record in topics:
+        topic_dir = output_dir / topic_record["topic_id"]
+        start = time.perf_counter()
+        result = None
+        error = None
+
+        try:
+            result = pipeline(topic_record["topic"])
+        except Exception as exc:  # pragma: no cover - benchmark safety path
+            error = f"{type(exc).__name__}: {exc}"
+
+        wall_time_sec = time.perf_counter() - start
+        metrics = build_smoke_metrics(
+            system=system,
+            topic_record=topic_record,
+            result=result,
+            wall_time_sec=wall_time_sec,
+            error=error,
+        ).to_dict()
+
+        write_json(topic_dir / "result.json", result or {})
+        write_json(topic_dir / "metrics.json", metrics)
+        all_metrics.append(metrics)
+
+    summary = summarize(all_metrics, system=system, mode=mode, use_llm=use_llm)
+    write_json(output_dir / "summary.json", summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--topics", type=Path, default=Path("benchmarks/arc_bench/topics_smoke.jsonl"))
+    parser.add_argument("--output", type=Path, default=Path("artifacts/arc_bench/adalflow_evolution_smoke"))
+    parser.add_argument("--mode", choices=["simple", "evolution"], default="evolution")
+    parser.add_argument("--max-iterations", type=int, default=5)
+    parser.add_argument("--use-llm", action="store_true")
+    parser.add_argument("--provider", choices=["openai", "groq", "anthropic"], default="openai")
+    parser.add_argument("--model", default="gpt-4o-mini")
+    parser.add_argument("--temperature", type=float, default=0.3)
+    args = parser.parse_args()
+
+    summary = run(
+        args.topics,
+        args.output,
+        mode=args.mode,
+        max_iterations=args.max_iterations,
+        use_llm=args.use_llm,
+        provider=args.provider,
+        model_kwargs={"model": args.model, "temperature": args.temperature},
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/arc_bench/topics_smoke.jsonl
+++ b/benchmarks/arc_bench/topics_smoke.jsonl
@@ -1,0 +1,5 @@
+{"topic_id": "ml_001", "domain": "ml", "topic": "Investigate whether prompt self-reflection improves parameter-efficient tuning stability on small reasoning tasks."}
+{"topic_id": "ml_002", "domain": "ml", "topic": "Evaluate self-healing code generation loops for automatically repairing failed ML experiment scripts."}
+{"topic_id": "stats_001", "domain": "statistics", "topic": "Compare bootstrap confidence intervals with Bayesian credible intervals for small-sample simulation studies."}
+{"topic_id": "bio_001", "domain": "biology", "topic": "Design a computational experiment to test whether pathway-level summaries improve gene expression classification robustness."}
+{"topic_id": "quantum_001", "domain": "quantum", "topic": "Explore whether noise-aware variational circuit ansatz selection improves robustness under simulated depolarizing noise."}

--- a/use_cases/multi_agent_dag/auto_research_claw_demo.py
+++ b/use_cases/multi_agent_dag/auto_research_claw_demo.py
@@ -1,0 +1,206 @@
+"""
+AdalFlow Implementation of an Autonomous Research Agent (AutoResearchClaw-style).
+This demo showcases how AdalFlow's Component architecture, Prompt Parameters, and Custom Evaluators 
+can model a multi-stage autonomous research pipeline with Human-in-the-Loop (HITL) gates, 
+Self-Healing code sandboxes, and run-to-run Optimization.
+"""
+
+import sys
+import time
+from typing import Dict, Any, List, Optional
+from adalflow.core.component import Component
+from adalflow.optim.parameter import Parameter, ParameterType
+
+# =====================================================================
+# 1. Pipeline Building Blocks: AdalFlow Stages and Components
+# =====================================================================
+
+class LiteratureAgent(Component):
+    """
+    Search and analyze relevant literature using scholarly APIs.
+    """
+    def __init__(self):
+        super().__init__()
+        self.system_prompt = Parameter(
+            data="You are an expert literature surveyor. Identify key research papers, extract findings, and isolate open research gaps.",
+            requires_opt=True,
+            role_desc="Instructions for LiteratureAgent to maximize relevance and coverage of references.",
+            param_type=ParameterType.PROMPT
+        )
+
+    def call(self, topic: str) -> List[Dict[str, str]]:
+        print(f"\n[LiteratureAgent] Searching real & virtual databases for topic: '{topic}'")
+        # In a real environment, we would call OpenAlex or Semantic Scholar APIs here.
+        # Returning mock reference results.
+        return [
+            {"title": "AdalFlow: Auto-optimizing LLM pipelines", "authors": "Yang et al.", "year": "2024"},
+            {"title": "AutoResearchClaw: Autonomous Research Agents", "authors": "Liu et al.", "year": "2026"}
+        ]
+
+
+class HypothesisAgent(Component):
+    """
+    Synthesize literature findings and design testable hypotheses.
+    """
+    def __init__(self):
+        super().__init__()
+        self.system_prompt = Parameter(
+            data="Formulate highly novel, testable machine learning hypotheses. Focus on parameter-efficient tuning.",
+            requires_opt=True,
+            role_desc="Synthesizing instructions to generate high-novelty hypotheses.",
+            param_type=ParameterType.PROMPT
+        )
+
+    def call(self, literature_findings: List[Dict[str, str]]) -> str:
+        print("[HypothesisAgent] Analyzing findings to generate a novel research hypothesis...")
+        return "Hypothesis: AdalFlow's Textual Gradient Descent (TGD) is more sample-efficient than standard RLHF on reasoning tasks."
+
+
+class SecureSandboxExecutor(Component):
+    """
+    Secure executor which runs the generated code in a sandbox, catches errors, 
+    and returns traceback feedback for self-healing.
+    """
+    def call(self, code: str) -> Dict[str, Any]:
+        print("[Sandbox] Executing candidate experiment code in isolated sandbox...")
+        # Simulated run with error tracing
+        if "eval_accuracy" in code:
+            return {"status": "success", "metrics": {"eval_accuracy": 0.885}, "logs": "All checks passed."}
+        else:
+            return {"status": "failed", "traceback": "NameError: name 'eval_accuracy' is not defined", "logs": "Runtime execution failed."}
+
+
+class SelfHealingCoder(Component):
+    """
+    Self-healing execution module that writes code and iteratively repairs tracebacks.
+    """
+    def __init__(self):
+        super().__init__()
+        self.system_prompt = Parameter(
+            data="Write clean, modular, runnable training scripts. Ensure metrics like 'eval_accuracy' are tracked.",
+            requires_opt=True,
+            role_desc="System guidelines for compiling bug-free code.",
+            param_type=ParameterType.PROMPT
+        )
+        self.sandbox = SecureSandboxExecutor()
+
+    def call(self, hypothesis: str) -> Dict[str, Any]:
+        print("[Self-Healing Coder] Generating initial code based on hypothesis...")
+        code = "import torch\n# Running standard training sequence\nval_loss = 0.1"
+        
+        # Iteration 1: Sandbox run fails (simulated)
+        result = self.sandbox(code)
+        if result["status"] == "failed":
+            print(f"[Self-Healing Coder] Caught Error: {result['traceback']}. Initiating LLM self-healing repair loop...")
+            # Repairing code
+            code += "\neval_accuracy = 0.89"
+            result = self.sandbox(code)
+            
+        print(f"[Self-Healing Coder] Code execution finalized. Status: {result['status']}")
+        return result
+
+
+class HumanInTheLoopGate:
+    """
+    A lightweight HITL gate to pause execution, solicit user feedback, 
+    or auto-approve in head-less mode.
+    """
+    @staticmethod
+    def approve(stage_name: str, candidate_output: Any, mode: str = "co-pilot") -> Any:
+        print(f"\n--- [HITL Gate: {stage_name}] Mode: {mode} ---")
+        print(f"Candidate Proposal:\n{candidate_output}")
+        if mode == "auto":
+            print("Auto-approved.")
+            return candidate_output
+        
+        # Emulating standard CLI decision prompt
+        print("[HITL] Options: [a] Approve, [e] Edit, [c] Collaborate")
+        print("[HITL] Decision: Approved by default in this demo.")
+        return candidate_output
+
+
+# =====================================================================
+# 2. Main Orchestrator DAG Component
+# =====================================================================
+
+class AutoResearchPipeline(Component):
+    """
+    23-stage equivalent pipeline defined natively as an AdalFlow Component.
+    """
+    def __init__(self, hitl_mode: str = "co-pilot"):
+        super().__init__()
+        self.lit_agent = LiteratureAgent()
+        self.hyp_agent = HypothesisAgent()
+        self.coder = SelfHealingCoder()
+        self.hitl_mode = hitl_mode
+
+    def call(self, topic: str) -> Dict[str, Any]:
+        print(f"\n===== Initiating AutoResearchPipeline for Topic: '{topic}' =====")
+        
+        # Stage 1-6: Literature collection
+        papers = self.lit_agent(topic)
+        
+        # Stage 7-8: Hypothesis Generation & Multi-agent debate
+        raw_hypothesis = self.hyp_agent(papers)
+        
+        # Stage 9: Human-In-The-Loop gate
+        hypothesis = HumanInTheLoopGate.approve("HYPOTHESIS_GEN", raw_hypothesis, self.hitl_mode)
+        
+        # Stage 10-13: Code Gen & Sandbox Execution + Self-Healing
+        exp_result = self.coder(hypothesis)
+        
+        # Stage 14-23: Final output compilation
+        paper_status = "Successfully drafted NeurIPS-compatible LaTeX paper."
+        
+        return {
+            "hypothesis": hypothesis,
+            "experiment_metrics": exp_result.get("metrics", {}),
+            "output_status": paper_status
+        }
+
+
+# =====================================================================
+# 3. Demonstration & Mock Benchmark Execution
+# =====================================================================
+
+def demo_run():
+    # 1. Instantiate the modular pipeline
+    pipeline = AutoResearchPipeline(hitl_mode="co-pilot")
+    
+    # 2. Execute on a target topic
+    topic = "Optimize AdalFlow Prompting dynamically via self-referencing feedback loops."
+    result = pipeline(topic)
+    
+    print("\n" + "="*50)
+    print("DEMO EXECUTION SUMMARY:")
+    print(f"Hypothesis: {result['hypothesis']}")
+    print(f"Metrics:    {result['experiment_metrics']}")
+    print(f"Status:     {result['output_status']}")
+    print("="*50 + "\n")
+
+    # 3. Print out the Comparative Benchmark analysis
+    print_benchmark_report()
+
+def print_benchmark_report():
+    print("""
+=========================================================================================
+            ARC-BENCH SMOKE BENCHMARK STATUS
+=========================================================================================
+This demo is an AdalFlow-style autonomous research pipeline prototype. 
+
+To collect reproducible smoke benchmark metrics, run:
+
+python benchmarks/arc_bench/run_adalflow_smoke.py \
+  --topics benchmarks/arc_bench/topics_smoke.jsonl \
+  --output artifacts/arc_bench/adalflow_smoke
+
+Then generate the report:
+
+python benchmarks/arc_bench/report.py \
+  --input artifacts/arc_bench/adalflow_smoke \
+  --output artifacts/arc_bench/adalflow_smoke_report.md
+=========================================================================================
+""")
+
+if __name__ == "__main__":
+    demo_run()

--- a/use_cases/multi_agent_dag/open_evolve_research_demo.py
+++ b/use_cases/multi_agent_dag/open_evolve_research_demo.py
@@ -1,0 +1,563 @@
+"""
+OpenEvolve-style autonomous research loop demo built with AdalFlow Components.
+
+This is a deterministic, local smoke-testable prototype by default. It models the
+structure of an evolutionary research agent:
+
+    seed -> mutate -> execute -> evaluate -> reflect -> archive -> repeat
+
+Phase 1 also supports optional LLM-backed seed/mutation/reflection/report writing.
+The executor and evaluator stay deterministic/safe so benchmark runs remain
+reproducible unless explicitly switched to LLM mode.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+from adalflow.components.model_client import AnthropicAPIClient, GroqAPIClient, OpenAIClient
+from adalflow.core.component import Component
+from adalflow.core.generator import Generator
+from adalflow.optim.parameter import Parameter, ParameterType
+
+
+@dataclass
+class ResearchCandidate:
+    """A candidate research direction/program in the evolution loop."""
+
+    candidate_id: str
+    parent_id: Optional[str]
+    generation: int
+    topic: str
+    hypothesis: str
+    experiment_code: str
+    score: float = 0.0
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    feedback: str = ""
+    repaired: bool = False
+
+
+@dataclass
+class ResearchState:
+    """Mutable state for one autonomous research run."""
+
+    topic: str
+    candidates: List[ResearchCandidate] = field(default_factory=list)
+    lessons: List[str] = field(default_factory=list)
+    best_candidate_id: Optional[str] = None
+    iteration: int = 0
+
+    @property
+    def best_candidate(self) -> Optional[ResearchCandidate]:
+        if self.best_candidate_id is None:
+            return None
+        for candidate in self.candidates:
+            if candidate.candidate_id == self.best_candidate_id:
+                return candidate
+        return None
+
+
+def _stable_unit_interval(*parts: str) -> float:
+    """Return a deterministic float in [0, 1) for reproducible smoke tests."""
+
+    digest = hashlib.sha256("::".join(parts).encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) / 0xFFFFFFFF
+
+
+def _generator_text(response: Any) -> str:
+    """Extract a text payload from an AdalFlow Generator response."""
+
+    data = getattr(response, "data", response)
+    if data is None:
+        raw_response = getattr(response, "raw_response", None)
+        return "" if raw_response is None else str(raw_response)
+    return str(data).strip()
+
+
+def _build_model_client(provider: str):
+    """Create a model client for optional LLM-backed demo components."""
+
+    if provider == "openai":
+        return OpenAIClient()
+    if provider == "groq":
+        return GroqAPIClient()
+    if provider == "anthropic":
+        return AnthropicAPIClient()
+    raise ValueError(f"Unsupported provider: {provider}")
+
+
+class LLMBackedComponent(Component):
+    """Small helper for optional Generator-backed research agents."""
+
+    def __init__(self, *, provider: str, model_kwargs: Dict[str, Any], template: str):
+        super().__init__()
+        self.generator = Generator(
+            model_client=_build_model_client(provider),
+            model_kwargs=model_kwargs,
+            template=template,
+        )
+
+    def generate_text(self, prompt_kwargs: Dict[str, Any]) -> str:
+        return _generator_text(self.generator(prompt_kwargs=prompt_kwargs))
+
+
+class SeedAgent(Component):
+    """Create the initial hypothesis and experiment sketch."""
+
+    def __init__(self):
+        super().__init__()
+        self.system_prompt = Parameter(
+            data=(
+                "Create an initial research candidate with a concrete hypothesis, "
+                "simple experiment plan, and measurable success criterion."
+            ),
+            requires_opt=True,
+            role_desc="Seed instructions for the first research candidate.",
+            param_type=ParameterType.PROMPT,
+        )
+
+    def call(self, topic: str) -> ResearchCandidate:
+        return ResearchCandidate(
+            candidate_id="cand-000",
+            parent_id=None,
+            generation=0,
+            topic=topic,
+            hypothesis=f"Initial hypothesis for: {topic}",
+            experiment_code="# initial experiment\nmetric = baseline_score",
+        )
+
+
+class LLMSeedAgent(LLMBackedComponent):
+    """LLM-backed seed agent that drafts the first research hypothesis."""
+
+    def __init__(self, *, provider: str, model_kwargs: Dict[str, Any]):
+        super().__init__(
+            provider=provider,
+            model_kwargs=model_kwargs,
+            template=(
+                "You are a research agent creating the first candidate for an "
+                "evolutionary autonomous research loop.\n\n"
+                "Topic: {{topic}}\n\n"
+                "Return a concise hypothesis and experiment sketch. Keep it specific, "
+                "measurable, and safe to evaluate in a sandbox."
+            ),
+        )
+
+    def call(self, topic: str) -> ResearchCandidate:
+        hypothesis = self.generate_text({"topic": topic})
+        if not hypothesis:
+            hypothesis = f"Initial hypothesis for: {topic}"
+
+        return ResearchCandidate(
+            candidate_id="cand-000",
+            parent_id=None,
+            generation=0,
+            topic=topic,
+            hypothesis=hypothesis,
+            experiment_code="# llm-seeded experiment\nmetric = baseline_score",
+        )
+
+
+class MutationAgent(Component):
+    """Generate child candidates from the current best candidate and lessons."""
+
+    def __init__(self):
+        super().__init__()
+        self.system_prompt = Parameter(
+            data=(
+                "Mutate the current research candidate using evaluator feedback. "
+                "Prefer small, testable changes with clear measurement hooks."
+            ),
+            requires_opt=True,
+            role_desc="Mutation policy for improving research candidates.",
+            param_type=ParameterType.PROMPT,
+        )
+
+    def call(
+        self,
+        parent: ResearchCandidate,
+        *,
+        topic: str,
+        lessons: List[str],
+        generation: int,
+    ) -> ResearchCandidate:
+        lesson_hint = lessons[-1] if lessons else "start with a measurable baseline"
+        candidate_id = f"cand-{generation:03d}"
+        hypothesis = (
+            f"{parent.hypothesis} | refinement {generation}: "
+            f"apply lesson '{lesson_hint}'"
+        )
+
+        code = (
+            f"# candidate {candidate_id}\n"
+            f"# parent: {parent.candidate_id}\n"
+            "metric = baseline_score\n"
+            f"improvement_step = {generation}\n"
+        )
+
+        # Odd generations intentionally omit eval_accuracy so the repair path is exercised.
+        if generation % 2 == 0:
+            code += "eval_accuracy = 0.70 + 0.03 * improvement_step\n"
+
+        return ResearchCandidate(
+            candidate_id=candidate_id,
+            parent_id=parent.candidate_id,
+            generation=generation,
+            topic=topic,
+            hypothesis=hypothesis,
+            experiment_code=code,
+        )
+
+
+class LLMMutationAgent(LLMBackedComponent):
+    """LLM-backed mutation agent.
+
+    The LLM mutates the research direction, while the experiment code remains a
+    deterministic skeleton for safe smoke benchmarking.
+    """
+
+    def __init__(self, *, provider: str, model_kwargs: Dict[str, Any]):
+        super().__init__(
+            provider=provider,
+            model_kwargs=model_kwargs,
+            template=(
+                "You are mutating a research candidate in an OpenEvolve-style loop.\n\n"
+                "Topic: {{topic}}\n"
+                "Generation: {{generation}}\n"
+                "Parent candidate:\n{{parent}}\n\n"
+                "Recent lessons:\n{{lessons}}\n\n"
+                "Return one improved hypothesis and experiment direction. Prefer a "
+                "small testable change, not a broad rewrite."
+            ),
+        )
+
+    def call(
+        self,
+        parent: ResearchCandidate,
+        *,
+        topic: str,
+        lessons: List[str],
+        generation: int,
+    ) -> ResearchCandidate:
+        candidate_id = f"cand-{generation:03d}"
+        hypothesis = self.generate_text(
+            {
+                "topic": topic,
+                "generation": generation,
+                "parent": asdict(parent),
+                "lessons": "\n".join(lessons[-3:]) if lessons else "No prior lessons.",
+            }
+        )
+        if not hypothesis:
+            hypothesis = f"{parent.hypothesis} | LLM refinement {generation}"
+
+        code = (
+            f"# candidate {candidate_id}\n"
+            f"# parent: {parent.candidate_id}\n"
+            "metric = baseline_score\n"
+            f"improvement_step = {generation}\n"
+        )
+        if generation % 2 == 0:
+            code += "eval_accuracy = 0.70 + 0.03 * improvement_step\n"
+
+        return ResearchCandidate(
+            candidate_id=candidate_id,
+            parent_id=parent.candidate_id,
+            generation=generation,
+            topic=topic,
+            hypothesis=hypothesis,
+            experiment_code=code,
+        )
+
+
+class EvolutionSandboxExecutor(Component):
+    """Mock sandbox executor with deterministic repair behavior."""
+
+    def call(self, candidate: ResearchCandidate) -> ResearchCandidate:
+        if "eval_accuracy" not in candidate.experiment_code:
+            candidate.metrics["first_attempt_error"] = "Missing eval_accuracy metric"
+            candidate.experiment_code += "eval_accuracy = 0.68 + 0.025 * improvement_step\n"
+            candidate.repaired = True
+
+        candidate.metrics["status"] = "success"
+        candidate.metrics["eval_accuracy"] = round(
+            0.65
+            + 0.04 * candidate.generation
+            + 0.03 * _stable_unit_interval(candidate.topic, candidate.candidate_id),
+            4,
+        )
+        return candidate
+
+
+class ResearchEvaluator(Component):
+    """Score candidates from execution metrics and lightweight quality signals."""
+
+    def call(self, candidate: ResearchCandidate) -> float:
+        accuracy = float(candidate.metrics.get("eval_accuracy", 0.0))
+        novelty_bonus = 0.02 * min(candidate.generation, 3)
+        repair_penalty = 0.01 if candidate.repaired else 0.0
+        score = accuracy + novelty_bonus - repair_penalty
+        candidate.score = round(score, 4)
+        return candidate.score
+
+
+class ReflectorAgent(Component):
+    """Convert candidate outcomes into reusable lessons for the next mutation."""
+
+    def __init__(self):
+        super().__init__()
+        self.system_prompt = Parameter(
+            data=(
+                "Diagnose candidate results and produce concise, reusable lessons "
+                "for the next mutation."
+            ),
+            requires_opt=True,
+            role_desc="Reflection instructions for extracting lessons from runs.",
+            param_type=ParameterType.PROMPT,
+        )
+
+    def call(self, candidate: ResearchCandidate) -> str:
+        if candidate.repaired:
+            feedback = (
+                f"{candidate.candidate_id}: keep explicit metric logging; repaired missing "
+                "eval_accuracy before scoring."
+            )
+        else:
+            feedback = (
+                f"{candidate.candidate_id}: metric logging was complete; continue refining "
+                "experiment specificity."
+            )
+        candidate.feedback = feedback
+        return feedback
+
+
+class LLMReflectorAgent(LLMBackedComponent):
+    """LLM-backed reflection agent for lesson extraction."""
+
+    def __init__(self, *, provider: str, model_kwargs: Dict[str, Any]):
+        super().__init__(
+            provider=provider,
+            model_kwargs=model_kwargs,
+            template=(
+                "You are reflecting on an evolutionary research candidate.\n\n"
+                "Candidate:\n{{candidate}}\n\n"
+                "Write one concise reusable lesson for the next mutation. Mention "
+                "metric logging, repair, novelty, or experiment design only if relevant."
+            ),
+        )
+
+    def call(self, candidate: ResearchCandidate) -> str:
+        feedback = self.generate_text({"candidate": asdict(candidate)})
+        if not feedback:
+            feedback = ReflectorAgent().call(candidate)
+        candidate.feedback = feedback
+        return feedback
+
+
+class CandidateArchive(Component):
+    """Track lineage, lessons, and best candidate selection."""
+
+    def call(
+        self,
+        state: ResearchState,
+        candidate: ResearchCandidate,
+        feedback: str,
+    ) -> ResearchState:
+        state.candidates.append(candidate)
+        state.lessons.append(feedback)
+
+        best = state.best_candidate
+        if best is None or candidate.score >= best.score:
+            state.best_candidate_id = candidate.candidate_id
+
+        return state
+
+
+class FinalReportWriter(Component):
+    """Produce a final report artifact from the best candidate."""
+
+    def call(self, state: ResearchState) -> Dict[str, Any]:
+        best = state.best_candidate
+        if best is None:
+            return {
+                "output_status": "Failed to produce final report.",
+                "paper_generated": False,
+            }
+
+        return {
+            "output_status": "Successfully drafted evolution-loop research report.",
+            "paper_generated": True,
+            "hypothesis": best.hypothesis,
+            "best_candidate": asdict(best),
+            "lessons": state.lessons,
+        }
+
+
+class LLMFinalReportWriter(LLMBackedComponent):
+    """LLM-backed report writer for final research summaries."""
+
+    def __init__(self, *, provider: str, model_kwargs: Dict[str, Any]):
+        super().__init__(
+            provider=provider,
+            model_kwargs=model_kwargs,
+            template=(
+                "You are writing a concise research progress report from an "
+                "OpenEvolve-style autonomous research loop.\n\n"
+                "Topic: {{topic}}\n"
+                "Best candidate:\n{{best_candidate}}\n\n"
+                "Lessons:\n{{lessons}}\n\n"
+                "Return Markdown with sections: Hypothesis, Experiment, Results, "
+                "Lessons, Next Steps."
+            ),
+        )
+
+    def call(self, state: ResearchState) -> Dict[str, Any]:
+        best = state.best_candidate
+        if best is None:
+            return {
+                "output_status": "Failed to produce final report.",
+                "paper_generated": False,
+            }
+
+        report_markdown = self.generate_text(
+            {
+                "topic": state.topic,
+                "best_candidate": asdict(best),
+                "lessons": "\n".join(state.lessons[-5:]),
+            }
+        )
+
+        return {
+            "output_status": "Successfully drafted LLM-backed evolution-loop research report.",
+            "paper_generated": True,
+            "hypothesis": best.hypothesis,
+            "best_candidate": asdict(best),
+            "lessons": state.lessons,
+            "report_markdown": report_markdown,
+        }
+
+
+class OpenEvolveResearchLoop(Component):
+    """OpenEvolve-style research loop orchestrator."""
+
+    def __init__(
+        self,
+        max_iterations: int = 5,
+        target_score: float = 0.86,
+        *,
+        use_llm: bool = False,
+        provider: str = "openai",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__()
+        self.max_iterations = max_iterations
+        self.target_score = target_score
+        self.use_llm = use_llm
+
+        llm_model_kwargs = model_kwargs or {"model": "gpt-4o-mini", "temperature": 0.3}
+
+        if use_llm:
+            self.seed_agent = LLMSeedAgent(provider=provider, model_kwargs=llm_model_kwargs)
+            self.mutator = LLMMutationAgent(provider=provider, model_kwargs=llm_model_kwargs)
+            self.reflector = LLMReflectorAgent(provider=provider, model_kwargs=llm_model_kwargs)
+            self.final_writer = LLMFinalReportWriter(provider=provider, model_kwargs=llm_model_kwargs)
+        else:
+            self.seed_agent = SeedAgent()
+            self.mutator = MutationAgent()
+            self.reflector = ReflectorAgent()
+            self.final_writer = FinalReportWriter()
+
+        self.executor = EvolutionSandboxExecutor()
+        self.evaluator = ResearchEvaluator()
+        self.archive = CandidateArchive()
+
+    def call(self, topic: str) -> Dict[str, Any]:
+        print(f"\n===== OpenEvolveResearchLoop Topic: '{topic}' =====")
+        state = ResearchState(topic=topic)
+
+        seed = self.seed_agent(topic)
+        seed = self.executor(seed)
+        self.evaluator(seed)
+        feedback = self.reflector(seed)
+        state = self.archive(state, seed, feedback)
+
+        initial_score = seed.score
+        retry_count = 1 if seed.repaired else 0
+        convergence_iteration = seed.generation
+
+        for generation in range(1, self.max_iterations + 1):
+            state.iteration = generation
+            parent = state.best_candidate
+            if parent is None:
+                break
+
+            candidate = self.mutator(
+                parent,
+                topic=topic,
+                lessons=state.lessons,
+                generation=generation,
+            )
+            candidate = self.executor(candidate)
+            if candidate.repaired:
+                retry_count += 1
+
+            self.evaluator(candidate)
+            feedback = self.reflector(candidate)
+            previous_best = state.best_candidate
+            state = self.archive(state, candidate, feedback)
+
+            if state.best_candidate is not None and (
+                previous_best is None or state.best_candidate.candidate_id != previous_best.candidate_id
+            ):
+                convergence_iteration = generation
+
+            print(
+                f"[Evolution] generation={generation} "
+                f"candidate={candidate.candidate_id} score={candidate.score:.4f} "
+                f"best={state.best_candidate.score:.4f}"
+            )
+
+            if state.best_candidate and state.best_candidate.score >= self.target_score:
+                break
+
+        report = self.final_writer(state)
+        best = state.best_candidate
+        best_score = best.score if best else 0.0
+
+        result = {
+            **report,
+            "llm_enabled": self.use_llm,
+            "experiment_metrics": {
+                "best_score": best_score,
+                "initial_score": initial_score,
+                "score_improvement": round(best_score - initial_score, 4),
+                "num_candidates": len(state.candidates),
+                "retry_count": retry_count,
+                "convergence_iteration": convergence_iteration,
+                "archive_size": len(state.candidates),
+            },
+            "evolution_history": [asdict(candidate) for candidate in state.candidates],
+        }
+        return result
+
+
+def demo_run() -> None:
+    loop = OpenEvolveResearchLoop(max_iterations=5)
+    result = loop(
+        "Investigate whether iterative prompt mutation improves autonomous research reliability."
+    )
+    print("\n" + "=" * 60)
+    print("OPENEVOLVE-STYLE DEMO SUMMARY")
+    print(f"Best score: {result['experiment_metrics']['best_score']}")
+    print(f"Improvement: {result['experiment_metrics']['score_improvement']}")
+    print(f"Candidates: {result['experiment_metrics']['num_candidates']}")
+    print(f"Retries: {result['experiment_metrics']['retry_count']}")
+    print(f"LLM enabled: {result['llm_enabled']}")
+    print(f"Status: {result['output_status']}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    demo_run()


### PR DESCRIPTION
## TL;DR

Adds an ARC-Bench-style smoke benchmark harness and an OpenEvolve-style autonomous research loop demo built with AdalFlow components.

## What changed

- Added `benchmarks/arc_bench/`
  - 5-topic smoke topic set
  - benchmark runner
  - normalized metrics schema
  - Markdown report generator
  - benchmark documentation
- Added `use_cases/multi_agent_dag/open_evolve_research_demo.py`
  - seed → mutate → execute/repair → evaluate → reflect → archive → repeat loop
  - deterministic default mode for reproducible smoke tests
  - optional LLM-backed seed/mutation/reflection/final-report components
- Added `use_cases/multi_agent_dag/auto_research_claw_demo.py`
  - simple linear research-agent prototype for control-flow comparison
- Updated `benchmarks/README.md`
  - documents deterministic and optional LLM-backed benchmark commands

## Why

This makes it easier to prototype autonomous research-agent systems in AdalFlow with a more realistic evolutionary control-flow shape than a one-shot linear agent pipeline.

The smoke benchmark intentionally avoids claiming a verified comparison against AutoResearchClaw. A fair comparison still requires running both systems under the same topic set, model, hardware, timeout, budget, and rubric.

## Testing

- Ran deterministic evolution smoke benchmark over 5 topics:
  - completion rate: 5/5
  - mean initial score: 0.65834
  - mean best score: 0.8833
  - mean score improvement: 0.22496
  - mean candidates: 5.0
  - mean retry count: 3.0
- Generated Markdown report successfully.
- Ran Python compile check on benchmark and demo files.
- Secret scan note: placeholder documentation contains `OPENAI_API_KEY="..."`; no real secret was committed.

🌸 Generated with [AdaL](https://github.com/adal-cli/)