### PR TITLE
fix: strip unsupported params for reasoning models & handle UnboundLocalError in Generator

### DIFF
--- a/adalflow/adalflow/components/model_client/openai_client.py
+++ b/adalflow/adalflow/components/model_client/openai_client.py
@@ -974,6 +974,27 @@ class OpenAIClient(ModelClient):
             else:
                 # Text-only input
                 final_model_kwargs["input"] = input
+
+            # Reasoning models (o1, o3-mini, etc.) do not support certain
+            # Chat Completion parameters in the Responses API.
+            # Strip them to avoid BadRequestError / unexpected keyword argument.
+            if model_type == ModelType.LLM_REASONING:
+                _REASONING_UNSUPPORTED_PARAMS = {
+                    "frequency_penalty",
+                    "presence_penalty",
+                    "temperature",
+                    "top_p",
+                }
+                removed = {
+                    k: final_model_kwargs.pop(k)
+                    for k in _REASONING_UNSUPPORTED_PARAMS
+                    if k in final_model_kwargs
+                }
+                if removed:
+                    log.warning(
+                        f"Reasoning model does not support {sorted(removed.keys())}; "
+                        f"removed from api_kwargs. Model: {final_model_kwargs.get('model', 'unknown')}"
+                    )
         else:
             raise ValueError(f"model_type {model_type} is not supported")
         return final_model_kwargs

--- a/adalflow/adalflow/core/generator.py
+++ b/adalflow/adalflow/core/generator.py
@@ -272,6 +272,16 @@ class Generator(GradComponent, CachedEngine, CallbackManager):
             output_fields = ["Answer"]
             output_mapping["Example"] = output_mapping["raw_response"]
             del output_mapping["raw_response"]
+        else:
+            # When both output.data and output.raw_response are None
+            # (e.g. API call failed entirely), provide a safe fallback
+            # to prevent UnboundLocalError at the return statement.
+            output_fields = []
+            output_mapping = {}
+            log.warning(
+                "Generator output has neither data nor raw_response. "
+                "Returning empty mapping. This usually indicates a failed API call."
+            )
 
         return output_mapping, output_fields
 

--- a/adalflow/tests/test_generator.py
+++ b/adalflow/tests/test_generator.py
@@ -313,5 +313,51 @@ class TestGeneratorIntegration(unittest.TestCase):
         self.assertIsInstance(output, GeneratorOutput)
 
 
+class TestGetDefaultMapping(unittest.TestCase):
+    """Test Generator._get_default_mapping handles all edge cases."""
+
+    def test_data_with_output_fields(self):
+        """When output.data is a DataClass with output fields, mapping should use them."""
+        from adalflow.core.base_data_class import DataClass
+        from adalflow.core.types import GeneratorOutput
+
+        class SampleOutput(DataClass):
+            answer: str = ""
+            score: float = 0.0
+
+        SampleOutput.set_output_fields(["answer", "score"])
+        data = SampleOutput()
+        data.answer = "test"
+        data.score = 0.9
+        output = GeneratorOutput(data=data)
+        mapping, fields = Generator._get_default_mapping(output)
+        self.assertIn("answer", fields)
+        self.assertIn("score", fields)
+        self.assertIn("answer", mapping)
+        self.assertIn("score", mapping)
+
+    def test_raw_response_only(self):
+        """When only raw_response is present, mapping should map 'Example' to raw_response."""
+        output = GeneratorOutput(raw_response="some text")
+        mapping, fields = Generator._get_default_mapping(output)
+        self.assertEqual(fields, ["Answer"])
+        self.assertIn("Example", mapping)
+
+    def test_both_data_and_raw_response_none(self):
+        """When both data and raw_response are None (API call failed),
+        should return empty mapping instead of raising UnboundLocalError."""
+        output = GeneratorOutput(data=None, raw_response=None, error="API call failed")
+        mapping, fields = Generator._get_default_mapping(output)
+        self.assertEqual(fields, [])
+        self.assertEqual(mapping, {})
+
+    def test_data_none_raw_response_empty_string(self):
+        """When raw_response is an empty string (falsy), should fall through to the else branch."""
+        output = GeneratorOutput(data=None, raw_response="")
+        mapping, fields = Generator._get_default_mapping(output)
+        self.assertEqual(fields, [])
+        self.assertEqual(mapping, {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/adalflow/tests/test_openai_client.py
+++ b/adalflow/tests/test_openai_client.py
@@ -730,6 +730,51 @@ class TestOpenAIClient(unittest.IsolatedAsyncioTestCase):
         # Assertions
         self.assertEqual("".join(text_chunks), "The answer is 42.")
 
+    def test_convert_inputs_to_api_kwargs_reasoning_model_strips_unsupported_params(self):
+        """Test that unsupported Chat Completion parameters are removed for reasoning models."""
+        model_kwargs = {
+            "model": "o3-mini",
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+            "temperature": 0.0,
+            "top_p": 0.99,
+            "reasoning": {"effort": "medium", "summary": "auto"},
+        }
+        result = self.client.convert_inputs_to_api_kwargs(
+            input="Solve this problem",
+            model_kwargs=model_kwargs,
+            model_type=ModelType.LLM_REASONING,
+        )
+        # Unsupported params should be removed
+        self.assertNotIn("frequency_penalty", result)
+        self.assertNotIn("presence_penalty", result)
+        self.assertNotIn("temperature", result)
+        self.assertNotIn("top_p", result)
+        # Supported params should remain
+        self.assertEqual(result["model"], "o3-mini")
+        self.assertIn("reasoning", result)
+        self.assertEqual(result["reasoning"]["effort"], "medium")
+
+    def test_convert_inputs_to_api_kwargs_llm_keeps_all_params(self):
+        """Test that regular LLM model_type keeps all parameters including frequency_penalty."""
+        model_kwargs = {
+            "model": "gpt-4o",
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+            "temperature": 0.0,
+            "top_p": 0.99,
+        }
+        result = self.client.convert_inputs_to_api_kwargs(
+            input="Hello",
+            model_kwargs=model_kwargs,
+            model_type=ModelType.LLM,
+        )
+        # All params should be preserved for regular LLM
+        self.assertIn("frequency_penalty", result)
+        self.assertIn("presence_penalty", result)
+        self.assertIn("temperature", result)
+        self.assertIn("top_p", result)
+
     def test_multiple_images_input(self):
         """Test multimodal input with multiple images."""
         # Test with multiple images


### PR DESCRIPTION
Fixes #481

## Summary

Two bugs fixed for Issue #481 (Quickstart Colab fails with frequency_penalty error on reasoning models):

### Bug 1: Reasoning models reject unsupported Chat Completion params
OpenAI Responses API rejects \requency_penalty\, \presence_penalty\, \	emperature\, and \	op_p\ for reasoning models (o1, o3-mini, etc.), causing \BadRequestError\.

**Fix:** Added parameter filtering in \OpenAIClient.convert_inputs_to_api_kwargs()\ — when \model_type == ModelType.LLM_REASONING\, these unsupported params are stripped from \inal_model_kwargs\ with a warning log.

### Bug 2: \UnboundLocalError\ in \Generator._get_default_mapping()\
When both \output.data\ and \output.raw_response\ were \None\ (e.g. API call failure), the method raised \UnboundLocalError\ because \output_mapping\ and \output_fields\ were never assigned.

**Fix:** Added an \else\ branch returning empty \output_mapping={}\ and \output_fields=[]\ with a warning log.

## Root Cause Analysis (Issue #481)
1. User runs Quickstart Colab with a reasoning model (e.g. o3-mini)
2. \compose_model_kwargs\ merges default model_kwargs including \requency_penalty\
3. \OpenAIClient\ passes \requency_penalty\ to OpenAI Responses API → \BadRequestError\
4. API call fails → \output.data\ and \output.raw_response\ are both None
5. \_get_default_mapping()\ has no else branch → \UnboundLocalError\

## Tests Added (6 new, all passing)
- \	est_convert_inputs_to_api_kwargs_reasoning_model_strips_unsupported_params\
- \	est_convert_inputs_to_api_kwargs_llm_keeps_all_params\
- \TestGetDefaultMapping\ class with 4 test cases:
  - \	est_data_with_output_fields\ — normal case
  - \	est_raw_response_only\ — fallback to raw_response
  - \	est_both_data_and_raw_response_none\ — the UnboundLocalError fix
  - \	est_data_none_raw_response_empty_string\ — edge case

## Files Changed
- \dalflow/adalflow/components/model_client/openai_client.py\ — strip unsupported params for LLM_REASONING
- \dalflow/adalflow/core/generator.py\ — add else branch in _get_default_mapping
- \dalflow/tests/test_openai_client.py\ — 2 new test methods
- \dalflow/tests/test_generator.py\ — new TestGetDefaultMapping class (4 tests)