### PR TITLE
docs: add Tesla T4 (Turing) hardware notes for local model clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+Notes for agents (and humans) working with AdalFlow's **local (transformers) model
+clients**, measured on a real NVIDIA Tesla T4 (16GB, Turing, `sm_75`).
+
+## Local (transformers) model client install
+
+AdalFlow is primarily a hosted-API framework (OpenAI/Anthropic/Cohere/Groq/...).
+If you want to use the **local** Hugging Face `transformers` path in
+`adalflow/adalflow/components/model_client/transformers_client.py`
+(`TransformerEmbedder`, `TransformerReranker`, `TransformerLLM`), note the following,
+which is not documented elsewhere:
+
+- There is no `transformers` extra in `adalflow/pyproject.toml`
+  (`[tool.poetry.extras]` only lists a `torch` extra). You need to install
+  `torch`, `transformers`, and `accelerate` yourself, matching your CUDA driver
+  (e.g. a machine with driver-level CUDA 12.4 needs a `cu124` torch build —
+  the default PyPI index can resolve to a newer CUDA build that reports
+  `torch.cuda.is_available() == False` on such a machine).
+- `openai` is marked `optional = true` in `adalflow/pyproject.toml`, but it is
+  required at import time even for the local-only path: `adalflow/adalflow/core/__init__.py`
+  imports `generator.py`, which does a top-level
+  `from openai.types.responses import ResponseCompletedEvent`. Without
+  `pip install openai`, `from adalflow.core.embedder import Embedder` fails with
+  `ModuleNotFoundError: No module named 'openai'`, even if you only intend to use
+  the local `transformers` embedder/reranker.
+- After installing, verify GPU visibility with
+  `python -c "import torch; print(torch.cuda.is_available())"` before running
+  local-model examples.
+
+## Local GPU inference surface (measured on Tesla T4)
+
+- **`TransformerEmbedder` (`thenlper/gte-base`) runs CPU-only, even when CUDA is
+  available.** Unlike its sibling `TransformerReranker`, it never calls
+  `.to(device)` on the model or the tokenizer output
+  (`transformers_client.py`, `TransformerEmbedder.__init__`/`infer_gte_base_embedding`).
+  Measured: `model_param_device=cpu`, peak VRAM `0.0GB` on a T4 box with CUDA
+  available. If you need GPU-accelerated local embeddings, use a different
+  client (e.g. `sentence-transformers` directly) or move the model/inputs to
+  `cuda` yourself.
+- **`TransformerReranker` (`BAAI/bge-reranker-base`) does run on GPU** via
+  `get_device()` + `self.model.to(device)` (`TransformerReranker.init_model`),
+  but it is loaded in **fp32** with no dtype knob exposed. On a Tesla T4
+  (Turing, `sm_75`), fp16 measured **~4.76x faster** than the fp32 default
+  (0.607s -> 0.128s warm, batch of 64 documents) and used **about half the
+  VRAM** (1.57GB -> 0.80GB). There is currently no supported way to request
+  fp16 for this client.
+- **`TransformerLLM` hardcodes `torch_dtype=torch.bfloat16`** in both its
+  pipeline path and its `AutoModelForCausalLM` path. Turing GPUs (T4, `sm_75`)
+  have no bf16 tensor cores, so this dtype is not accelerated on T4-class
+  hardware; fp16 is the correct choice there instead.
+- Overall, on a Tesla T4 the only local surface that actually uses the GPU is
+  the reranker; the local embedder silently stays on CPU. Peak VRAM across the
+  measured local surfaces stayed under ~1.6GB, well within a 16GB T4.
+
+These notes describe current, unchanged behavior of the code as of commit
+`810de99`; no default values or code paths were modified to produce them.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ async for event in streaming_result.stream_events():
 
 _Set your `OPENAI_API_KEY` environment variable to run these examples._
 
+_Using the local (Hugging Face `transformers`) model clients instead of a hosted API? See
+[AGENTS.md](./AGENTS.md) for install requirements and measured GPU behavior on
+Turing-class (e.g. Tesla T4) hardware._
+
 **Try the full Agent tutorial in Colab:** [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/SylphAI-Inc/AdalFlow/blob/main/notebooks/agents/agent_tutorial.ipynb)
 
 <!-- Please refer to the [full installation guide](https://adalflow.sylph.ai/get_started/installation.html) for more details.


### PR DESCRIPTION
## What does this PR do?

Doc-only PR adding Tesla T4 (Turing, `sm_75`) hardware notes for AdalFlow's local
(Hugging Face `transformers`) model clients. No issue filed — the PR template
notes this discussion step is "not for typos and docs".

### Motivation

AdalFlow is mostly a hosted-API framework, but it does have a local GPU inference
surface in `adalflow/adalflow/components/model_client/transformers_client.py`
(`TransformerEmbedder`, `TransformerReranker`, `TransformerLLM`). I ran this
surface end-to-end on a real **Tesla T4 (16GB, Turing, `sm_75`)** — driver
550.163.01, CUDA 12.4 runtime, torch 2.6.0+cu124, transformers 4.46.3 — and hit
undocumented gaps plus two hardware-relevant defaults worth writing down before
someone else hits them on the same class of GPU.

### Changes (docs only, no code/logic changes)

- **New `AGENTS.md`** documenting, with exact measurements:
  - `openai` is `optional = true` in `adalflow/pyproject.toml`, but it's required
    at *import time* even for the local-only path: `core/__init__.py` imports
    `generator.py`, which does a top-level
    `from openai.types.responses import ResponseCompletedEvent`. Without
    `pip install openai`, `from adalflow.core.embedder import Embedder` fails
    with `ModuleNotFoundError: No module named 'openai'` — even for users who
    only want the local `transformers` embedder/reranker.
  - There's no `transformers` extra in `adalflow/pyproject.toml` (only a `torch`
    extra), and no guidance on matching the torch build to your CUDA driver
    (e.g. driver-level CUDA 12.4 needs a `cu124` torch build, or
    `torch.cuda.is_available()` silently comes back `False`).
  - `TransformerEmbedder` (`thenlper/gte-base`) never calls `.to(device)` on the
    model or tokenizer output, so it runs **CPU-only even when CUDA is
    available** — measured `peak_vram=0.0GB` on the T4. Its sibling
    `TransformerReranker` does move to `get_device()`.
  - `TransformerReranker` (`BAAI/bge-reranker-base`) does run on GPU, but loads
    in **fp32** with no dtype knob. On the T4, fp16 measured **~4.76x faster**
    (0.607s -> 0.128s warm, batch of 64 docs) and **~half the VRAM**
    (1.57GB -> 0.80GB).
  - `TransformerLLM` hardcodes `torch_dtype=torch.bfloat16` in both its
    `pipeline` and `AutoModelForCausalLM` init paths. Turing GPUs (T4) have no
    bf16 tensor cores, so this default isn't accelerated on that hardware class.
- **README**: one-line pointer from the Quick Start section to `AGENTS.md` for
  users of the local model clients.

Nothing in `adalflow/` source changed — no default values, dtypes, or device
logic were touched. The underlying code-level issues (embedder missing device
placement, no fp16 knob on the reranker, bf16 hardcoded in the LLM client,
`openai` imported eagerly instead of lazily) are code/logic changes and out of
scope for this doc PR; happy to file separate issues for any of these if useful.

### Testing

Doc-only change (new `AGENTS.md` + one README line), no tests applicable. All
numbers above were measured by exercising the existing public API
(`adalflow.core.embedder.Embedder`, `RerankerRetriever`) unmodified, on:

- Tesla T4, 16GB, Turing (`sm_75`)
- driver 550.163.01, CUDA 12.4 runtime
- torch 2.6.0+cu124, transformers 4.46.3, accelerate 0.34.2, adalflow 1.1.1
- commit `810de99`

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? Not filed — doc-only, per the
  "not for typos and docs" note in this template.
- [x] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- Did you write any **new necessary tests**? Not applicable (docs only).
- [x] Did you verify new and **existing tests pass** locally with your changes? (no code changed; existing test suite unaffected)
- Did you list all the **breaking changes** introduced by this pull request? None — doc-only.

</details>
