### PR TITLE
add support to ollama batch embedding api

### DIFF
--- a/adalflow/adalflow/components/model_client/ollama_client.py
+++ b/adalflow/adalflow/components/model_client/ollama_client.py
@@ -367,8 +367,15 @@ class OllamaClient(ModelClient):
         Pull the embedding from response['embedding'] and store it Embedding dataclass
         """
         try:
-            embeddings = Embedding(embedding=response["embedding"], index=0)
-            return EmbedderOutput(data=[embeddings])
+            if "embedding" in response:
+                # results from legacy `embeddings` api
+                embeddings = [Embedding(embedding=response["embedding"], index=0)]
+            else:
+                embeddings = [
+                    Embedding(embedding=embed, index=i)
+                    for i, embed in enumerate(response["embeddings"])
+                ]
+            return EmbedderOutput(data=embeddings)
         except Exception as e:
             log.error(f"Error parsing the embedding response: {e}")
             return EmbedderOutput(data=[], error=str(e), raw_response=response)
@@ -380,7 +387,6 @@ class OllamaClient(ModelClient):
         model_type: ModelType = ModelType.UNDEFINED,
     ) -> Dict:
         r"""Convert the input and model_kwargs to api_kwargs for the Ollama SDK client."""
-        # TODO: ollama will support batch embedding in the future: https://ollama.com/blog/embedding-models
         self.generate = False  # reset generate to False
         final_model_kwargs = model_kwargs.copy()
         if model_type == ModelType.EMBEDDER:
@@ -388,9 +394,8 @@ class OllamaClient(ModelClient):
                 final_model_kwargs["prompt"] = input
                 return final_model_kwargs
             else:
-                raise ValueError(
-                    "Ollama does not support batch embedding yet. It only accepts a single string for input for now. Make sure you are not passing a list of strings"
-                )
+                final_model_kwargs["input"] = input
+            return final_model_kwargs
         elif model_type == ModelType.LLM:
             if input is not None and input != "":
                 # check if "generate" is in model_kwargs, and if it is set to True, then we use generate api
@@ -426,7 +431,10 @@ class OllamaClient(ModelClient):
         if self.sync_client is None:
             raise RuntimeError("Sync client is not initialized")
         if model_type == ModelType.EMBEDDER:
-            return self.sync_client.embeddings(**api_kwargs)
+            if "prompt" in api_kwargs:
+                return self.sync_client.embeddings(**api_kwargs)
+            else:
+                return self.sync_client.embed(**api_kwargs)
         if model_type == ModelType.LLM:
             if "generate" in api_kwargs and api_kwargs["generate"]:
                 # remove generate from api_kwargs
@@ -452,7 +460,11 @@ class OllamaClient(ModelClient):
         if "model" not in api_kwargs:
             raise ValueError("model must be specified")
         if model_type == ModelType.EMBEDDER:
-            return await self.async_client.embeddings(**api_kwargs)
+            if "prompt" in api_kwargs:
+                # using deprecated api for backward compatibility
+                return await self.async_client.embeddings(**api_kwargs)
+            else:
+                return await self.async_client.embed(**api_kwargs)
         if model_type == ModelType.LLM: # in default we use chat 
             # create a message from the input
             if "generate" in api_kwargs and api_kwargs["generate"]:

--- a/adalflow/adalflow/components/model_client/ollama_client.py
+++ b/adalflow/adalflow/components/model_client/ollama_client.py
@@ -361,7 +361,7 @@ class OllamaClient(ModelClient):
             return parse_chat_messsage(completion)
 
     def parse_embedding_response(
-        self, response: Dict[str, List[float]]
+        self, response: Dict[str, Union[List[float], List[List[float]]]]
     ) -> EmbedderOutput:
         r"""Parse the embedding response to a structure AdalFlow components can understand.
         Pull the embedding from response['embedding'] and store it Embedding dataclass

--- a/adalflow/tests/test_ollama_client.py
+++ b/adalflow/tests/test_ollama_client.py
@@ -71,7 +71,6 @@ class TestOllamaModelClient(unittest.TestCase):
 
     def test_ollama_embedding_client(self):
         client = OllamaClient()
-        ollama_client = Mock(spec=client)
         print("Testing ollama embedding client")
 
         # run the model
@@ -87,10 +86,14 @@ class TestOllamaModelClient(unittest.TestCase):
             "prompt": "Welcome",
             "model": "jina/jina-embeddings-v2-base-en:latest",
         }
-
-        output = ollama_client.call(
-            api_kwargs=api_kwargs, model_type=ModelType.EMBEDDER
-        ).return_value = {"embedding": [-0.7391586899757385]}
+        with patch.object(
+            client.sync_client,
+            "embeddings",
+            return_value={"embedding": [-0.7391586899757385]},
+        ):
+            output = client.call(
+                api_kwargs=api_kwargs, model_type=ModelType.EMBEDDER
+            )
         assert output == {"embedding": [-0.7391586899757385]}
 
         assert client.parse_embedding_response(output) == EmbedderOutput(
@@ -104,7 +107,6 @@ class TestOllamaModelClient(unittest.TestCase):
             self.skipTest("ollama version below `0.4.0`")
 
         client = OllamaClient()
-        mock_client = Mock(client)
 
         # run the model
         kwargs = {
@@ -120,9 +122,12 @@ class TestOllamaModelClient(unittest.TestCase):
             "model": "jina/jina-embeddings-v2-base-en:latest",
         }
 
-        output = mock_client.call(
-            api_kwargs=api_kwargs, model_type=ModelType.EMBEDDER
-        ).return_value = {"embeddings": [[0.1], [0.2]]}
+        with patch.object(
+                client.sync_client,
+                "embed",
+                return_value={"embeddings": [[0.1], [0.2]]},
+        ):
+            output = client.call(api_kwargs=api_kwargs, model_type=ModelType.EMBEDDER)
         assert output == {"embeddings": [[0.1], [0.2]]}
 
         embedder_output = client.parse_embedding_response(response=output)

--- a/adalflow/tests/test_ollama_client.py
+++ b/adalflow/tests/test_ollama_client.py
@@ -1,7 +1,7 @@
 import unittest
 import asyncio
 from unittest.mock import Mock, AsyncMock, MagicMock, patch
-from adalflow.core.types import ModelType, GeneratorOutput, Function
+from adalflow.core.types import ModelType, GeneratorOutput, Function, Embedding, EmbedderOutput
 from adalflow.components.model_client.ollama_client import OllamaClient, extract_ollama_tool_calls
 from typing import AsyncGenerator, Generator
 from ollama import ChatResponse, Message
@@ -70,21 +70,19 @@ class TestOllamaModelClient(unittest.TestCase):
         assert output == {"message": "Hello"}
 
     def test_ollama_embedding_client(self):
-        ollama_client = Mock(spec=OllamaClient())
+        client = OllamaClient()
+        ollama_client = Mock(spec=client)
         print("Testing ollama embedding client")
 
         # run the model
         kwargs = {
             "model": "jina/jina-embeddings-v2-base-en:latest",
         }
-        api_kwargs = ollama_client.convert_inputs_to_api_kwargs(
+        api_kwargs = client.convert_inputs_to_api_kwargs(
             input="Welcome",
             model_kwargs=kwargs,
             model_type=ModelType.EMBEDDER,
-        ).return_value = {
-            "prompt": "Welcome",
-            "model": "jina/jina-embeddings-v2-base-en:latest",
-        }
+        )
         assert api_kwargs == {
             "prompt": "Welcome",
             "model": "jina/jina-embeddings-v2-base-en:latest",
@@ -94,6 +92,45 @@ class TestOllamaModelClient(unittest.TestCase):
             api_kwargs=api_kwargs, model_type=ModelType.EMBEDDER
         ).return_value = {"embedding": [-0.7391586899757385]}
         assert output == {"embedding": [-0.7391586899757385]}
+
+        assert client.parse_embedding_response(output) == EmbedderOutput(
+            data=[Embedding(embedding=[-0.7391586899757385], index=0)]
+        )
+
+
+    def test_ollama_embed_client(self):
+        import ollama
+        if not hasattr(ollama, "embed"):
+            self.skipTest("ollama version below `0.4.0`")
+
+        client = OllamaClient()
+        mock_client = Mock(client)
+
+        # run the model
+        kwargs = {
+            "model": "jina/jina-embeddings-v2-base-en:latest",
+        }
+        api_kwargs = client.convert_inputs_to_api_kwargs(
+            input=["Welcome"] * 2,
+            model_kwargs=kwargs,
+            model_type=ModelType.EMBEDDER,
+        )
+        assert api_kwargs == {
+            "input": ["Welcome"] * 2,
+            "model": "jina/jina-embeddings-v2-base-en:latest",
+        }
+
+        output = mock_client.call(
+            api_kwargs=api_kwargs, model_type=ModelType.EMBEDDER
+        ).return_value = {"embeddings": [[0.1], [0.2]]}
+        assert output == {"embeddings": [[0.1], [0.2]]}
+
+        embedder_output = client.parse_embedding_response(response=output)
+
+        assert embedder_output == EmbedderOutput(data=[
+            Embedding(embedding=[0.1], index=0),
+            Embedding(embedding=[0.2], index=1),
+        ])
 
     def test_sync_streaming_chat(self):
         """Test synchronous streaming with chat API"""

--- a/adalflow/tests/test_ollama_client.py
+++ b/adalflow/tests/test_ollama_client.py
@@ -1,11 +1,9 @@
 import unittest
 import asyncio
-from unittest.mock import Mock, AsyncMock, MagicMock, patch
+from unittest.mock import Mock, AsyncMock, patch
 from adalflow.core.types import ModelType, GeneratorOutput, Function, Embedding, EmbedderOutput
 from adalflow.components.model_client.ollama_client import OllamaClient, extract_ollama_tool_calls
-from typing import AsyncGenerator, Generator
-from ollama import ChatResponse, Message
-from types import SimpleNamespace
+from ollama import Message
 
 # Create mock Ollama types that behave like the real ones
 # These simulate the actual Ollama API response objects


### PR DESCRIPTION
## What does this PR do?

Add support to call the ollama batch embedding API `embed` when possible. `embeddings` API was deprecated in version `0.4.0` ([chlog](https://github.com/ollama/ollama-python/releases/tag/v0.4.0))

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?


</details>


<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
