### PR TITLE
Fix: fix `OllamaClient.convert_inputs_to_api_kwargs` when LLM chat

### DIFF
--- a/adalflow/adalflow/components/model_client/ollama_client.py
+++ b/adalflow/adalflow/components/model_client/ollama_client.py
@@ -402,10 +402,10 @@ class OllamaClient(ModelClient):
                     # if the input is a string, we create a message with role "user"
                     if isinstance(input, str):
                         input = [{"role": "user", "content": input}]
-                        final_model_kwargs["messages"] = input
                     elif not isinstance(input, list):
                         raise ValueError("Input must be a string or a list of messages")
-                # if the input is a list of messages, we use it as is
+                    # if the input is a list of messages, we use it as is
+                    final_model_kwargs["messages"] = input
                 return final_model_kwargs
             else:
                 raise ValueError("Input must be text")


### PR DESCRIPTION
## What does this PR do?

Since the API endpoint already accepts a list of messages, preserve the original list input by passing it directly to final_model_kwargs["messages"] when model_type is LLM. This also aligns with the behavior described in the existing comments.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #\<issue_number>

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://adalflow.sylph.ai/contributor/index.html)?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?


</details>


<!--

Did you have fun?

Make sure you had fun coding 🙃

-->
