### PR TITLE
fix: strip unsupported params for reasoning models and fix UnboundLocalError in _get_default_mapping

### DIFF
--- a/adalflow/adalflow/components/model_client/openai_client.py
+++ b/adalflow/adalflow/components/model_client/openai_client.py
@@ -1032,6 +1032,15 @@ class OpenAIClient(ModelClient):
         #         self.chat_completion_parser = self.non_streaming_chat_completion_parser
         #         return self.sync_client.chat.completions.create(**api_kwargs)
         elif model_type == ModelType.LLM_REASONING or model_type == ModelType.LLM:
+            # Reasoning models (o1, o3, o4 series) do not support certain parameters
+            # in the Responses API. Strip them to avoid BadRequestError.
+            model_name = api_kwargs.get("model", "")
+            if model_name and any(model_name.startswith(prefix) for prefix in ("o1", "o3", "o4")):
+                for unsupported in ("frequency_penalty", "presence_penalty", "temperature"):
+                    if unsupported in api_kwargs:
+                        log.debug(f"Removing unsupported parameter '{unsupported}' for reasoning model '{model_name}'")
+                        api_kwargs.pop(unsupported)
+
             if "stream" in api_kwargs and api_kwargs.get("stream", False):
                 log.debug("streaming call")
                 self.response_parser = (
@@ -1087,6 +1096,15 @@ class OpenAIClient(ModelClient):
         #         # setting response parser as async non-streaming parser for Response API
         #         return await self.async_client.responses.create(**api_kwargs)
         elif model_type == ModelType.LLM or model_type == ModelType.LLM_REASONING:
+            # Reasoning models (o1, o3, o4 series) do not support certain parameters
+            # in the Responses API. Strip them to avoid BadRequestError.
+            model_name = api_kwargs.get("model", "")
+            if model_name and any(model_name.startswith(prefix) for prefix in ("o1", "o3", "o4")):
+                for unsupported in ("frequency_penalty", "presence_penalty", "temperature"):
+                    if unsupported in api_kwargs:
+                        log.debug(f"Removing unsupported parameter '{unsupported}' for reasoning model '{model_name}'")
+                        api_kwargs.pop(unsupported)
+
             if "stream" in api_kwargs and api_kwargs.get("stream", False):
                 log.debug("async streaming call")
                 self.response_parser = (

--- a/adalflow/adalflow/core/generator.py
+++ b/adalflow/adalflow/core/generator.py
@@ -256,6 +256,9 @@ class Generator(GradComponent, CachedEngine, CallbackManager):
         output: "GeneratorOutput" = None,
     ) -> Tuple[Dict[str, Callable], List[str]]:
 
+        output_mapping: Dict[str, Callable] = {}
+        output_fields: List[str] = []
+
         if (
             output.data
             and isinstance(output.data, DataClass)


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #481 that cause the quickstart Colab to crash when using `o3-mini` as the teacher model.

### Bug 1: `frequency_penalty` rejected by reasoning models

OpenAI reasoning models (`o1`, `o3`, `o4` series) do not accept `frequency_penalty`, `presence_penalty`, or `temperature` in the Responses API. When these parameters are passed (e.g. from default `model_kwargs`), every API call fails with:

```
Responses.create() got an unexpected keyword argument frequency_penalty
```

**Fix:** Before calling `responses.create()`, check if the model is a reasoning model (prefix `o1`, `o3`, `o4`) and strip unsupported parameters. Applied to both sync (`_call_model`) and async (`_acall_model`) code paths in `openai_client.py`.

### Bug 2: `UnboundLocalError` in `_get_default_mapping`

When all API calls fail (e.g. due to Bug 1), `output.data` and `output.raw_response` are both `None`/falsy. The `_get_default_mapping` method in `generator.py` only assigns `output_mapping` and `output_fields` inside `if`/`elif` branches, so when neither branch is taken, the variables are unbound:

```
UnboundLocalError: cannot access local variable output_mapping where it is not associated with a value
```

This confusing traceback hides the real cause (the API error).

**Fix:** Initialize `output_mapping` and `output_fields` with empty defaults before the `if`/`elif` block, so the function returns cleanly instead of crashing.

## Testing

- The `frequency_penalty` fix ensures reasoning models work without manual kwarg removal.
- The `UnboundLocalError` fix ensures that when API calls fail, the error is surfaced clearly rather than masked by a secondary crash.

Fixes #481